### PR TITLE
Adds filtering of partial matches to classifications/detections

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://app.viam.com/module/erh/filtered-camera
   "camera": "my-cam",
   "vision": "my-vision-service",
   "classifications": {
-    "COUNTDOWN*": 0.5,
+    "COUNTDOWN*": 0.6,
     "ALARM": 0.5
   },
   "detections": {
@@ -25,6 +25,6 @@ https://app.viam.com/module/erh/filtered-camera
   }
 }
 ```
-For example, this config would save all images with a classification label that exactly matched "ALARM" or partially matched "COUNTDOWN", e.g. "COUNTDOWN: 10 s remain!". It would also save all images that had any detection with a confidence above 0.85.  
+For example, this config would save all images with a classification label that exactly matched "ALARM" with greater than 0.5 confidence, or partially matched "COUNTDOWN", e.g. "COUNTDOWN: 10 s remain!" with greater than 0.6 confidence. It would also save all images that had any detection with a confidence above 0.85.  
 
 

--- a/README.md
+++ b/README.md
@@ -6,3 +6,25 @@ You can say either classify an image and only sync some, or look for object in a
 
 https://app.viam.com/module/erh/filtered-camera
 
+### Example Config
+
+```
+"name": "filter",
+"model": "erh:camera:filtered-camera",
+"type": "camera",
+"namespace": "rdk",
+"attributes" : {
+  "camera": "my-cam",
+  "vision": "my-vision-service",
+  "classifications": {
+    "COUNTDOWN*": 0.5,
+    "ALARM": 0.5
+  },
+  "detections": {
+   "*": 0.85
+  }
+}
+```
+For example, this config would save all images with a classification label that exactly matched "ALARM" or partially matched "COUNTDOWN", e.g. "COUNTDOWN: 10 s remain!". It would also save all images that had any detection with a confidence above 0.85.  
+
+

--- a/cam.go
+++ b/cam.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"image"
 	"sort"
+	"strings"
+	"regexp"
 	"sync"
 	"time"
 
@@ -53,6 +55,17 @@ func (cfg *Config) keepClassification(c classification.Classification) bool {
 	if has && c.Score() > min {
 		return true
 	}
+	// check for substring match
+	for key, _ := range cfg.Classifications {
+		if strings.Contains(key, "*") {
+			if match, err := regexp.MatchString(key, c.Label()); match {
+				if err != nil {
+					continue
+				}
+				return true
+			}
+		}
+	}
 
 	return false
 }
@@ -77,7 +90,17 @@ func (cfg *Config) keepObject(d objectdetection.Detection) bool {
 	if has && d.Score() > min {
 		return true
 	}
-
+	// check for substring match
+	for key, _ := range cfg.Objects {
+		if strings.Contains(key, "*") {
+			if match, err := regexp.MatchString(key, d.Label()); match {
+				if err != nil {
+					continue
+				}
+				return true
+			}
+		}
+	}
 	return false
 }
 


### PR DESCRIPTION
Using a wildcard character, you can match to partial classification/detection labels.

For example,
 if your config is
```
{
  "camera": "my-cam",
  "vision": "my-cision",
  "classifications": {
    "COUNTDOWN*": 0.9
  }
}
```
Then images that have the classification label "COUNTDOWN: 20 s remain!" will also be saved