### PR TITLE
Separate img buffer

### DIFF
--- a/cam.go
+++ b/cam.go
@@ -131,11 +131,6 @@ type filteredCamera struct {
 	vis vision.Service
 
 	buf imagebuffer.ImageBuffer
-
-	//mu          sync.Mutex
-	//buffer      []cachedData
-	//toSend      []cachedData
-	//captureTill time.Time
 }
 
 func (fc *filteredCamera) Name() resource.Name {

--- a/cam_test.go
+++ b/cam_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	imagebuffer "github.com/viam-modules/filtered_camera/image_buffer"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/vision"
@@ -124,31 +125,31 @@ func TestWindow(t *testing.T) {
 	b := time.Now().Add(-1 * time.Second)
 	c := time.Now().Add(-1 * time.Minute)
 
-	fc.buffer = []cachedData{
-		{meta: resource.ResponseMetadata{CapturedAt: a}},
-		{meta: resource.ResponseMetadata{CapturedAt: b}},
-		{meta: resource.ResponseMetadata{CapturedAt: c}},
+	fc.buf.Buffer = []imagebuffer.CachedData{
+		{Meta: resource.ResponseMetadata{CapturedAt: a}},
+		{Meta: resource.ResponseMetadata{CapturedAt: b}},
+		{Meta: resource.ResponseMetadata{CapturedAt: c}},
 	}
 
-	fc.markShouldSend()
+	fc.buf.MarkShouldSend(fc.conf.WindowSeconds)
 
-	test.That(t, len(fc.buffer), test.ShouldEqual, 0)
-	test.That(t, len(fc.toSend), test.ShouldEqual, 2)
-	test.That(t, b, test.ShouldEqual, fc.toSend[0].meta.CapturedAt)
-	test.That(t, a, test.ShouldEqual, fc.toSend[1].meta.CapturedAt)
+	test.That(t, len(fc.buf.Buffer), test.ShouldEqual, 0)
+	test.That(t, len(fc.buf.ToSend), test.ShouldEqual, 2)
+	test.That(t, b, test.ShouldEqual, fc.buf.ToSend[0].Meta.CapturedAt)
+	test.That(t, a, test.ShouldEqual, fc.buf.ToSend[1].Meta.CapturedAt)
 
-	fc.buffer = []cachedData{
-		{meta: resource.ResponseMetadata{CapturedAt: c}},
-		{meta: resource.ResponseMetadata{CapturedAt: b}},
-		{meta: resource.ResponseMetadata{CapturedAt: a}},
+	fc.buf.Buffer = []imagebuffer.CachedData{
+		{Meta: resource.ResponseMetadata{CapturedAt: c}},
+		{Meta: resource.ResponseMetadata{CapturedAt: b}},
+		{Meta: resource.ResponseMetadata{CapturedAt: a}},
 	}
-	fc.toSend = []cachedData{}
+	fc.buf.ToSend = []imagebuffer.CachedData{}
 
-	fc.markShouldSend()
+	fc.buf.MarkShouldSend(fc.conf.WindowSeconds)
 
-	test.That(t, len(fc.buffer), test.ShouldEqual, 0)
-	test.That(t, len(fc.toSend), test.ShouldEqual, 2)
-	test.That(t, b, test.ShouldEqual, fc.toSend[0].meta.CapturedAt)
-	test.That(t, a, test.ShouldEqual, fc.toSend[1].meta.CapturedAt)
+	test.That(t, len(fc.buf.Buffer), test.ShouldEqual, 0)
+	test.That(t, len(fc.buf.ToSend), test.ShouldEqual, 2)
+	test.That(t, b, test.ShouldEqual, fc.buf.ToSend[0].Meta.CapturedAt)
+	test.That(t, a, test.ShouldEqual, fc.buf.ToSend[1].Meta.CapturedAt)
 
 }

--- a/conditional_camera/conditional_cam.go
+++ b/conditional_camera/conditional_cam.go
@@ -83,11 +83,6 @@ type conditionalCamera struct {
 	filtSvc resource.Resource
 
 	buf imagebuffer.ImageBuffer
-
-	//mu          sync.Mutex
-	//buffer      []cachedData
-	//toSend      []cachedData
-	//captureTill time.Time
 }
 
 func (cc *conditionalCamera) Name() resource.Name {
@@ -166,7 +161,6 @@ func (cc *conditionalCamera) Image(ctx context.Context, mimeType string, extra m
 func (cc *conditionalCamera) Close(ctx context.Context) error {
 	return cc.cam.Close(ctx)
 }
-
 
 func (cc *conditionalCamera) shouldSend(ctx context.Context) (bool, error) {
 

--- a/image_buffer/image_buffer.go
+++ b/image_buffer/image_buffer.go
@@ -1,0 +1,73 @@
+package imagebuffer
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/resource"
+)
+
+type CachedData struct {
+	Imgs []camera.NamedImage
+	Meta resource.ResponseMetadata
+}
+
+// ImageBuffer is a buffer for images.
+type ImageBuffer struct {
+	Mu          sync.Mutex
+	Buffer      []CachedData
+	ToSend      []CachedData
+	CaptureTill time.Time
+}
+
+func (ib *ImageBuffer) AddToBuffer_inlock(imgs []camera.NamedImage, meta resource.ResponseMetadata, windowSeconds int) {
+	if windowSeconds == 0 {
+		return
+	}
+
+	ib.CleanBuffer_inlock(windowSeconds)
+	ib.Buffer = append(ib.Buffer, CachedData{imgs, meta})
+}
+
+func (ib *ImageBuffer) CleanBuffer_inlock(windowSeconds int) {
+	sort.Slice(ib.Buffer, func(i, j int) bool {
+		a := ib.Buffer[i]
+		b := ib.Buffer[j]
+		return a.Meta.CapturedAt.Before(b.Meta.CapturedAt)
+	})
+
+	windowDuration := time.Duration(windowSeconds) * time.Second
+	early := time.Now().Add(-1 * windowDuration)
+	for len(ib.Buffer) > 0 {
+		if ib.Buffer[0].Meta.CapturedAt.After(early) {
+			return
+		}
+		ib.Buffer = ib.Buffer[1:]
+	}
+}
+
+func (ib *ImageBuffer) MarkShouldSend(windowSeconds int) {
+	ib.Mu.Lock()
+	defer ib.Mu.Unlock()
+
+	windowDuration := time.Duration(windowSeconds) * time.Second
+	ib.CaptureTill = time.Now().Add(windowDuration)
+	ib.CleanBuffer_inlock(windowSeconds)
+
+	ib.ToSend = append(ib.ToSend, ib.Buffer...)
+	ib.Buffer = []CachedData{}
+}
+
+// Mutex should be locked before running this command
+func (ib *ImageBuffer) SendFromBuffer() ([]camera.NamedImage, resource.ResponseMetadata, error) {
+	if len(ib.ToSend) > 0 {
+		x := ib.ToSend[0]
+		ib.ToSend = ib.ToSend[1:]
+		return x.Imgs, x.Meta, nil
+	}
+
+	return nil, resource.ResponseMetadata{}, nil
+
+}


### PR DESCRIPTION
Back to the filtered_cam module.  Since we have 2 models that use the exact same logic for the image buffer, I'm separating it out into its own package that both can import and use.  Tests are coming next and then I'll merge it all into the actual main branch.  