### PR TITLE
[RSDK-9983][RSDK-9987] - Allow for use of 1 or more vision services

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ The following attributes are available for `viam:camera:filtered-camera` bases:
 | `classifications` | float64 | Optional | \*\***DEPRECATED**\*\* A map of classification labels and the confidence scores required for filtering. Use this if the ML model behind your vision service is a classifier. You can find these labels by testing your vision service. |
 | `objects` | float64 | Optional | \*\***DEPRECATED**\*\* A map of object detection labels and the confidence scores required for filtering. Use this if the ML model behind your vision service is a detector. You can find these labels by testing your vision service. |
 
+> [!WARNING]
+> If a vision service has no specified classifications and/or objects, it won't trigger any data capture.
+
 ### Example configurations
 
 ```json

--- a/README.md
+++ b/README.md
@@ -23,16 +23,19 @@ On the new component panel, copy and paste the following attribute template into
 ```json
 {
     "camera": "<your_camera_name>",
-    "vision": "<your_vision_service_name>",
+    "vision_services": [
+        {
+            "vision": <first_vision_service>,
+            "classifications": ...,
+            "objects": ...
+        },
+        {
+            "vision": <second_vision_service>,
+            "classifications": ...,
+            "objects": ...
+        }
+    ],
     "window_seconds": <time_window_for_capture>,
-    "classifications": {
-        "<label>": <confidence_score>,
-        "<label>": <confidence_score>
-    },
-    "objects": {
-        "<label>": <confidence_score>,
-        "<label>": <confidence_score>
-    }
 }
 ```
 
@@ -48,21 +51,32 @@ The following attributes are available for `viam:camera:filtered-camera` bases:
 | Name | Type | Inclusion | Description |
 | ---- | ------ | ------------ | ----------- |
 | `camera` | string | **Required** | The name of the camera to filter images for. |
-| `vision` | string | **Required** | The vision service used for image classifications or detections. |
+| `vision_services` | list | **Required** | A list of 1 or more vision services used for image classifications or detections. |
+| `vision` | string | **Required** | \*\***DEPRECATED**\*\* The vision service used for image classifications or detections. |
 | `window_seconds` | float64 | Optional | The size of the time window (in seconds) during which images are buffered. When a condition is met, a confidence score for a detection/classification exceeds the required confidence score, the buffered images are stored, allowing us to see the photos taken in the N number of seconds preceding the condition being met. |
-| `classifications` | float64 | Optional | A map of classification labels and the confidence scores required for filtering. Use this if the ML model behind your vision service is a classifier. You can find these labels by testing your vision service. |
-| `objects` | float64 | Optional | A map of object detection labels and the confidence scores required for filtering. Use this if the ML model behind your vision service is a detector. You can find these labels by testing your vision service. |
+| `classifications` | float64 | Optional | \*\***DEPRECATED**\*\* A map of classification labels and the confidence scores required for filtering. Use this if the ML model behind your vision service is a classifier. You can find these labels by testing your vision service. |
+| `objects` | float64 | Optional | \*\***DEPRECATED**\*\* A map of object detection labels and the confidence scores required for filtering. Use this if the ML model behind your vision service is a detector. You can find these labels by testing your vision service. |
 
 ### Example configurations
 
 ```json
 {
     "camera": "my_camera",
-    "vision": "my_red_car_detector",
+    "vision_services": [
+        {
+            "vision": "my_red_car_detector",
+            "objects": {
+                "red_car": 0.6
+            }
+        },
+        {
+            "vision": "my_cat_classifier",
+            "classifications": {
+                "cat": 0.6
+            }
+        }
+    ],
     "windowSeconds": 5,
-    "objects": {
-        "red_car": 0.6
-    }
 }
 ```
 

--- a/cam.go
+++ b/cam.go
@@ -2,6 +2,7 @@ package filtered_camera
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"image"
 	"time"
@@ -23,57 +24,26 @@ var Model = Family.WithModel("filtered-camera")
 type Config struct {
 	Camera        string
 	Vision        string
-	WindowSeconds int `json:"window_seconds"`
+	VisionServices []VisionServiceConfig `json:"vision_services,omitempty"`
+	WindowSeconds  int                   `json:"window_seconds"`
 
 	Classifications map[string]float64
 	Objects         map[string]float64
 }
 
-func (cfg *Config) keepClassifications(cs []classification.Classification) bool {
-	for _, c := range cs {
-		if cfg.keepClassification(c) {
-			return true
-		}
-	}
-	return false
+type VisionServiceConfig struct {
+	Vision          string             `json:"vision"`
+	Objects         map[string]float64 `json:"objects,omitempty"`
+	Classifications map[string]float64 `json:"classifications,omitempty"`
 }
 
-func (cfg *Config) keepClassification(c classification.Classification) bool {
-	min, has := cfg.Classifications[c.Label()]
-	if has && c.Score() > min {
-		return true
+// Validate ensures all parts of the config are valid.
+func (config *VisionServiceConfig) Validate(path string) error {
+	if config.Vision == "" {
+		return resource.NewConfigValidationFieldRequiredError(path, "vision")
 	}
 
-	min, has = cfg.Classifications["*"]
-	if has && c.Score() > min {
-		return true
-	}
-
-	return false
-}
-
-func (cfg *Config) keepObjects(ds []objectdetection.Detection) bool {
-	for _, d := range ds {
-		if cfg.keepObject(d) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (cfg *Config) keepObject(d objectdetection.Detection) bool {
-	min, has := cfg.Objects[d.Label()]
-	if has && d.Score() > min {
-		return true
-	}
-
-	min, has = cfg.Objects["*"]
-	if has && d.Score() > min {
-		return true
-	}
-
-	return false
+	return nil
 }
 
 func (cfg *Config) Validate(path string) ([]string, error) {
@@ -81,11 +51,26 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "camera")
 	}
 
-	if cfg.Vision == "" {
+	if cfg.Vision == "" && cfg.VisionServices == nil {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "vision")
+	} else if cfg.Vision != "" && cfg.VisionServices != nil {
+		return nil, utils.NewConfigValidationError(path, errors.New("cannot specify both vision and vision_services"))
 	}
 
-	return []string{cfg.Camera, cfg.Vision}, nil
+	deps := []string{cfg.Camera}
+
+	if cfg.Vision != "" {
+		deps = append(deps, cfg.Vision)
+	} else {
+		for idx, vs := range cfg.VisionServices {
+			if err := vs.Validate(fmt.Sprintf("%s.%s.%d", path, "vision-service", idx)); err != nil {
+				return nil, err
+			}
+			deps = append(deps, vs.Vision)
+		}
+	}
+
+	return deps, nil
 }
 
 func init() {
@@ -102,10 +87,40 @@ func init() {
 			if err != nil {
 				return nil, err
 			}
+			if newConf.Vision != "" {
+				fc.visionServices = make([]vision.Service, 1)
+				fc.visionServices[0], err = vision.FromDependencies(deps, newConf.Vision)
+				if err != nil {
+					return nil, err
+				}
 
-			fc.vis, err = vision.FromDependencies(deps, newConf.Vision)
-			if err != nil {
-				return nil, err
+				if newConf.Classifications != nil {
+					fc.allClassifications = make(map[string]map[string]float64)
+					fc.allClassifications[newConf.Vision] = newConf.Classifications
+				} else {
+					fc.allObjects = make(map[string]map[string]float64)
+					fc.allObjects[newConf.Vision] = newConf.Objects
+				}
+			} else {
+				fc.visionServices = make([]vision.Service, len(newConf.VisionServices))
+				for i, vs := range newConf.VisionServices {
+					fc.visionServices[i], err = vision.FromDependencies(deps, vs.Vision)
+					if err != nil {
+						return nil, err
+					}
+
+					if vs.Classifications != nil {
+						if fc.allClassifications == nil {
+							fc.allClassifications = make(map[string]map[string]float64)
+						}
+						fc.allClassifications[vs.Vision] = vs.Classifications
+					} else {
+						if fc.allObjects == nil {
+							fc.allObjects = make(map[string]map[string]float64)
+						}
+						fc.allObjects[vs.Vision] = vs.Objects
+					}
+				}
 			}
 
 			return fc, nil
@@ -121,9 +136,58 @@ type filteredCamera struct {
 	conf   *Config
 	logger logging.Logger
 
-	cam camera.Camera
-	vis vision.Service
-	buf imagebuffer.ImageBuffer
+	cam                camera.Camera
+	buf                imagebuffer.ImageBuffer
+	visionServices     []vision.Service
+	allClassifications map[string]map[string]float64
+	allObjects         map[string]map[string]float64
+}
+
+func (fc *filteredCamera) keepClassifications(visionService string, cs []classification.Classification) bool {
+	for _, c := range cs {
+		if fc.keepClassification(visionService, c) {
+			return true
+		}
+	}
+	return false
+}
+
+func (fc *filteredCamera) keepClassification(visionService string, c classification.Classification) bool {
+	min, has := fc.allClassifications[visionService][c.Label()]
+	if has && c.Score() > min {
+		return true
+	}
+
+	min, has = fc.allClassifications[visionService]["*"]
+	if has && c.Score() > min {
+		return true
+	}
+
+	return false
+}
+
+func (fc *filteredCamera) keepObjects(visionService string, ds []objectdetection.Detection) bool {
+	for _, d := range ds {
+		if fc.keepObject(visionService, d) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (fc *filteredCamera) keepObject(visionService string, d objectdetection.Detection) bool {
+	min, has := fc.allObjects[visionService][d.Label()]
+	if has && d.Score() > min {
+		return true
+	}
+
+	min, has = fc.allObjects[visionService]["*"]
+	if has && d.Score() > min {
+		return true
+	}
+
+	return false
 }
 
 func (fc *filteredCamera) Name() resource.Name {
@@ -184,36 +248,37 @@ func (fc *filteredCamera) images(ctx context.Context, extra map[string]interface
 }
 
 func (fc *filteredCamera) shouldSend(ctx context.Context, img image.Image) (bool, error) {
+	for _, vs := range fc.visionServices {
+		if len(fc.allClassifications[vs.Name().Name]) > 0 {
+			res, err := vs.Classifications(ctx, img, 100, nil)
+			if err != nil {
+				return false, err
+			}
 
-	if len(fc.conf.Classifications) > 0 {
-		res, err := fc.vis.Classifications(ctx, img, 100, nil)
-		if err != nil {
-			return false, err
+			if fc.keepClassifications(vs.Name().Name, res) {
+				fc.logger.Debugf("keeping image with classifications %v", res)
+				fc.buf.MarkShouldSend(fc.conf.WindowSeconds)
+				return true, nil
+			}
 		}
 
-		if fc.conf.keepClassifications(res) {
-			fc.logger.Debugf("keeping image with classifications %v", res)
-			fc.buf.MarkShouldSend(fc.conf.WindowSeconds)
+		if len(fc.allObjects[vs.Name().Name]) > 0 {
+			res, err := vs.Detections(ctx, img, nil)
+			if err != nil {
+				return false, err
+			}
+
+			if fc.keepObjects(vs.Name().Name, res) {
+				fc.logger.Debugf("keeping image with objects %v", res)
+				fc.buf.MarkShouldSend(fc.conf.WindowSeconds)
+				return true, nil
+			}
+		}
+
+		if time.Now().Before(fc.buf.CaptureTill) {
+			// send, but don't update captureTill
 			return true, nil
 		}
-	}
-
-	if len(fc.conf.Objects) > 0 {
-		res, err := fc.vis.Detections(ctx, img, nil)
-		if err != nil {
-			return false, err
-		}
-
-		if fc.conf.keepObjects(res) {
-			fc.logger.Debugf("keeping image with objects %v", res)
-			fc.buf.MarkShouldSend(fc.conf.WindowSeconds)
-			return true, nil
-		}
-	}
-
-	if time.Now().Before(fc.buf.CaptureTill) {
-		// send, but don't update captureTill
-		return true, nil
 	}
 
 	return false, nil

--- a/cam_test.go
+++ b/cam_test.go
@@ -180,7 +180,7 @@ func TestValidate(t *testing.T) {
 	res, err = conf.Validate(".")
 	test.That(t, res, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "\"vision\" is required")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "\"vision_services\" is required")
 
 	conf.Vision = "foo"
 	res, err = conf.Validate(".")

--- a/cam_test.go
+++ b/cam_test.go
@@ -211,6 +211,30 @@ func TestValidate(t *testing.T) {
 	test.That(t, res, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res, test.ShouldResemble, []string{"foo", "foo", "bar"})
+
+	// vision services can implement both classifier and detector
+	conf.VisionServices = []VisionServiceConfig{
+		{
+			Vision:          "foo",
+			Classifications: map[string]float64{"a": .8},
+			Objects: 	   	 map[string]float64{"a": .8},
+		},
+	}
+	res, err = conf.Validate(".")
+	test.That(t, res, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, res, test.ShouldResemble, []string{"foo", "foo"})
+
+	// vision services can not have any classifications or objects
+	conf.VisionServices = []VisionServiceConfig{
+		{
+			Vision: "foo",
+		},
+	}
+	res, err = conf.Validate(".")
+	test.That(t, res, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, res, test.ShouldResemble, []string{"foo", "foo"})
 }
 
 func TestImage(t *testing.T) {

--- a/cam_test.go
+++ b/cam_test.go
@@ -226,6 +226,7 @@ func TestValidate(t *testing.T) {
 	test.That(t, res, test.ShouldResemble, []string{"foo", "foo"})
 
 	// vision services can not have any classifications or objects
+	// this would mean that no images would be captured
 	conf.VisionServices = []VisionServiceConfig{
 		{
 			Vision: "foo",


### PR DESCRIPTION
## Changes
- [x] Add `VisionServices` field to config with validation
- [x] Ensure either `Vision` or `VisionServices` is being used
- [x] Create a master classifications and objects map (used for both old and new config)
- [x] edit `keepClassifications/Objects` to work with one or multiple vision services
- [x] test all logic (unit tests and env tests)