### PR TITLE
[RSDK-9984] - add inhibitor field to config

### DIFF
--- a/cam.go
+++ b/cam.go
@@ -61,7 +61,7 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 
 	deps := []string{cfg.Camera}
 	inhibitors := []string{}
-	optherVisionServices := []string{}
+	otherVisionServices := []string{}
 
 	if cfg.Vision != "" {
 		logger := logging.NewBlankLogger("deprecated")
@@ -75,13 +75,13 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 			if vs.Inhibit {
 				inhibitors = append(inhibitors, vs.Vision)
 			} else {
-				optherVisionServices = append(optherVisionServices, vs.Vision)
+				otherVisionServices = append(otherVisionServices, vs.Vision)
 			}
 		}
 	}
 
 	deps = append(deps, inhibitors...)
-	deps = append(deps, optherVisionServices...)
+	deps = append(deps, otherVisionServices...)
 
 	return deps, nil
 }

--- a/cam.go
+++ b/cam.go
@@ -60,6 +60,8 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 	}
 
 	deps := []string{cfg.Camera}
+	inhibitors := []string{}
+	optherVisionServices := []string{}
 
 	if cfg.Vision != "" {
 		logger := logging.NewBlankLogger("deprecated")
@@ -70,9 +72,16 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 			if err := vs.Validate(fmt.Sprintf("%s.%s.%d", path, "vision-service", idx)); err != nil {
 				return nil, err
 			}
-			deps = append(deps, vs.Vision)
+			if vs.Inhibit {
+				inhibitors = append(inhibitors, vs.Vision)
+			} else {
+				optherVisionServices = append(optherVisionServices, vs.Vision)
+			}
 		}
 	}
+
+	deps = append(deps, inhibitors...)
+	deps = append(deps, optherVisionServices...)
 
 	return deps, nil
 }

--- a/cam_test.go
+++ b/cam_test.go
@@ -70,7 +70,7 @@ func TestShouldSend(t *testing.T) {
 			Objects:         map[string]float64{"b": .8},
 		},
 		logger: logger,
-		visionServices: []vision.Service{
+		otherVisionServices: []vision.Service{
 			getDummyVisionService(),
 		},
 		allClassifications: map[string]map[string]float64{"": {"a": .8}},
@@ -117,7 +117,9 @@ func TestShouldSend(t *testing.T) {
 	// test inhibit should not send with classifications
 	fc.allClassifications = map[string]map[string]float64{"": {"a": .7}}
 	fc.allObjects = map[string]map[string]float64{}
-	fc.inhibitors = map[string]bool{"": true}
+	fc.inhibitors = []vision.Service{
+		getDummyVisionService(),
+	}
 	res, err = fc.shouldSend(context.Background(), a)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res, test.ShouldEqual, false)
@@ -140,7 +142,7 @@ func TestWindow(t *testing.T) {
 			WindowSeconds:   10,
 		},
 		logger: logger,
-		visionServices: []vision.Service{
+		otherVisionServices: []vision.Service{
 			getDummyVisionService(),
 		},
 	}
@@ -231,7 +233,7 @@ func TestValidate(t *testing.T) {
 		{
 			Vision:          "foo",
 			Classifications: map[string]float64{"a": .8},
-			Objects: 	   	 map[string]float64{"a": .8},
+			Objects:         map[string]float64{"a": .8},
 		},
 	}
 	res, err = conf.Validate(".")
@@ -254,16 +256,16 @@ func TestValidate(t *testing.T) {
 	// inhibitors should be first in the dependency list
 	conf.VisionServices = []VisionServiceConfig{
 		{
-			Vision:          "foo",
-			Inhibit:         false,
+			Vision:  "foo",
+			Inhibit: false,
 		},
 		{
-			Vision:          "bar",
-			Inhibit: 	   	 false,
+			Vision:  "bar",
+			Inhibit: false,
 		},
 		{
-			Vision:          "baz",
-			Inhibit: 	   	 true,
+			Vision:  "baz",
+			Inhibit: true,
 		},
 	}
 	res, err = conf.Validate(".")
@@ -282,10 +284,10 @@ func TestImage(t *testing.T) {
 			WindowSeconds:   10,
 		},
 		logger: logger,
-		visionServices: []vision.Service{
+		otherVisionServices: []vision.Service{
 			getDummyVisionService(),
 		},
-		buf:    imagebuffer.ImageBuffer{},
+		buf: imagebuffer.ImageBuffer{},
 		cam: &inject.Camera{
 			ImagesFunc: func(ctx context.Context) ([]camera.NamedImage, resource.ResponseMetadata, error) {
 				return []camera.NamedImage{
@@ -329,10 +331,10 @@ func TestImages(t *testing.T) {
 			WindowSeconds:   10,
 		},
 		logger: logger,
-		visionServices: []vision.Service{
+		otherVisionServices: []vision.Service{
 			getDummyVisionService(),
 		},
-		buf:    imagebuffer.ImageBuffer{},
+		buf: imagebuffer.ImageBuffer{},
 		cam: &inject.Camera{
 			ImagesFunc: func(ctx context.Context) ([]camera.NamedImage, resource.ResponseMetadata, error) {
 				return namedImages, resource.ResponseMetadata{CapturedAt: timestamp}, nil
@@ -357,9 +359,9 @@ func TestProperties(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
 	properties := camera.Properties{
-		SupportsPCD:    false,
-		ImageType:    	camera.ImageType("color"),
-		MimeTypes:  	[]string{utils.MimeTypeJPEG},
+		SupportsPCD: false,
+		ImageType:   camera.ImageType("color"),
+		MimeTypes:   []string{utils.MimeTypeJPEG},
 	}
 
 	fc := &filteredCamera{
@@ -369,10 +371,10 @@ func TestProperties(t *testing.T) {
 			WindowSeconds:   10,
 		},
 		logger: logger,
-		visionServices: []vision.Service{
+		otherVisionServices: []vision.Service{
 			getDummyVisionService(),
 		},
-		buf:    imagebuffer.ImageBuffer{},
+		buf: imagebuffer.ImageBuffer{},
 		cam: &inject.Camera{
 			PropertiesFunc: func(ctx context.Context) (camera.Properties, error) {
 				return properties, nil

--- a/cam_test.go
+++ b/cam_test.go
@@ -250,6 +250,26 @@ func TestValidate(t *testing.T) {
 	test.That(t, res, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res, test.ShouldResemble, []string{"foo", "foo"})
+
+	// inhibitors should be first in the dependency list
+	conf.VisionServices = []VisionServiceConfig{
+		{
+			Vision:          "foo",
+			Inhibit:         false,
+		},
+		{
+			Vision:          "bar",
+			Inhibit: 	   	 false,
+		},
+		{
+			Vision:          "baz",
+			Inhibit: 	   	 true,
+		},
+	}
+	res, err = conf.Validate(".")
+	test.That(t, res, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, res, test.ShouldResemble, []string{"foo", "baz", "foo", "bar"})
 }
 
 func TestImage(t *testing.T) {

--- a/cam_test.go
+++ b/cam_test.go
@@ -114,12 +114,20 @@ func TestShouldSend(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res, test.ShouldEqual, true)
 
-	// test inhibit
+	// test inhibit should not send with classifications
+	fc.allClassifications = map[string]map[string]float64{"": {"a": .7}}
+	fc.allObjects = map[string]map[string]float64{}
 	fc.inhibitors = map[string]bool{"": true}
 	res, err = fc.shouldSend(context.Background(), a)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res, test.ShouldEqual, false)
 
+	// test inhibit should not send with objects
+	fc.allClassifications = map[string]map[string]float64{}
+	fc.allObjects = map[string]map[string]float64{"": {"b": .1}}
+	res, err = fc.shouldSend(context.Background(), b)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, res, test.ShouldEqual, false)
 }
 
 func TestWindow(t *testing.T) {

--- a/cam_test.go
+++ b/cam_test.go
@@ -114,6 +114,12 @@ func TestShouldSend(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res, test.ShouldEqual, true)
 
+	// test inhibit
+	fc.inhibitors = map[string]bool{"": true}
+	res, err = fc.shouldSend(context.Background(), a)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, res, test.ShouldEqual, false)
+
 }
 
 func TestWindow(t *testing.T) {


### PR DESCRIPTION
## Changes
- [x] add `Inhibit` field to vision service config
- [x] put inhibitor services first in dependency list 
- [x] create map of inhibitor vision services
- [x] prevent images from sending to data capture if classificiation/detection is true and vision service is in inhibitor map 
- [x] write unit and local tests 