### PR TITLE
[RSDK-9986] show captured images instead of live feed in app

### DIFF
--- a/cam.go
+++ b/cam.go
@@ -288,7 +288,7 @@ func (fc *filteredCamera) images(ctx context.Context, extra map[string]interface
 	}
 
 	if !IsFromDataMgmt(ctx, extra) {
-		return fc.lastCached(), meta, nil
+		return fc.buf.LastCached.Imgs, fc.buf.LastCached.Meta, nil
 	}
 
 	for _, img := range images {
@@ -314,14 +314,7 @@ func (fc *filteredCamera) images(ctx context.Context, extra map[string]interface
 		return x.Imgs, x.Meta, nil
 	}
 
-	return fc.lastCached(), meta, data.ErrNoCaptureToStore
-}
-
-func (fc *filteredCamera) lastCached() []camera.NamedImage {
-	if fc.buf.LastCached != nil {
-		return fc.buf.LastCached
-	}
-	return nil
+	return fc.buf.LastCached.Imgs, fc.buf.LastCached.Meta, data.ErrNoCaptureToStore
 }
 
 func (fc *filteredCamera) shouldSend(ctx context.Context, img image.Image) (bool, error) {

--- a/cam_test.go
+++ b/cam_test.go
@@ -8,6 +8,7 @@ import (
 
 	imagebuffer "github.com/viam-modules/filtered_camera/image_buffer"
 	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/data"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/rimage"
@@ -332,9 +333,12 @@ func TestImage(t *testing.T) {
 				}, resource.ResponseMetadata{}, nil
 			},
 		},
+		allClassifications: map[string]map[string]float64{"": {"a": .8}},
+		allObjects:         map[string]map[string]float64{"": {"b": .8}},
 	}
 
 	ctx := context.Background()
+	ctx = context.WithValue(ctx, data.FromDMContextKey{}, true)
 
 	res, meta, err := fc.Image(ctx, utils.MimeTypeJPEG, nil)
 	test.That(t, err, test.ShouldBeNil)
@@ -375,9 +379,12 @@ func TestImages(t *testing.T) {
 				return namedImages, resource.ResponseMetadata{CapturedAt: timestamp}, nil
 			},
 		},
+		allClassifications: map[string]map[string]float64{"": {"a": .8}},
+		allObjects:         map[string]map[string]float64{"": {"b": .8}},
 	}
 
 	ctx := context.Background()
+	ctx = context.WithValue(ctx, data.FromDMContextKey{}, true)
 
 	res, meta, err := fc.Images(ctx)
 	test.That(t, err, test.ShouldBeNil)

--- a/cam_test.go
+++ b/cam_test.go
@@ -227,7 +227,6 @@ func TestValidate(t *testing.T) {
 	test.That(t, res, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "\"camera\" is required")
-
 	conf.Camera = "foo"
 	res, err = conf.Validate(".")
 	test.That(t, res, test.ShouldBeNil)

--- a/image_buffer/image_buffer.go
+++ b/image_buffer/image_buffer.go
@@ -19,7 +19,7 @@ type ImageBuffer struct {
 	Buffer      []CachedData
 	ToSend      []CachedData
 	CaptureTill time.Time
-	LastCached  []camera.NamedImage
+	LastCached  CachedData
 }
 
 func (ib *ImageBuffer) windowDuration(windowSeconds int) time.Duration {
@@ -67,5 +67,10 @@ func (ib *ImageBuffer) CacheImages(images []camera.NamedImage) {
 	ib.Mu.Lock()
 	defer ib.Mu.Unlock()
 
-	ib.LastCached = images
+	ib.LastCached = CachedData{
+		Imgs: images,
+		Meta: resource.ResponseMetadata{
+			CapturedAt: time.Now(),
+		},
+	}
 }

--- a/image_buffer/image_buffer.go
+++ b/image_buffer/image_buffer.go
@@ -61,3 +61,14 @@ func (ib *ImageBuffer) MarkShouldSend(windowSeconds int) {
 
 	ib.Buffer = []CachedData{}
 }
+
+func (ib *ImageBuffer) LastCaptured() []camera.NamedImage {
+	ib.Mu.Lock()
+	defer ib.Mu.Unlock()
+
+	if len(ib.ToSend) == 0 {
+		return nil
+	}
+
+	return ib.ToSend[len(ib.ToSend)-1].Imgs
+}

--- a/image_buffer/image_buffer.go
+++ b/image_buffer/image_buffer.go
@@ -19,6 +19,7 @@ type ImageBuffer struct {
 	Buffer      []CachedData
 	ToSend      []CachedData
 	CaptureTill time.Time
+	LastCached  []camera.NamedImage
 }
 
 func (ib *ImageBuffer) windowDuration(windowSeconds int) time.Duration {
@@ -62,13 +63,9 @@ func (ib *ImageBuffer) MarkShouldSend(windowSeconds int) {
 	ib.Buffer = []CachedData{}
 }
 
-func (ib *ImageBuffer) LastCaptured() []camera.NamedImage {
+func (ib *ImageBuffer) CacheImages(images []camera.NamedImage) {
 	ib.Mu.Lock()
 	defer ib.Mu.Unlock()
 
-	if len(ib.ToSend) == 0 {
-		return nil
-	}
-
-	return ib.ToSend[len(ib.ToSend)-1].Imgs
+	ib.LastCached = images
 }


### PR DESCRIPTION
## Changes
- [x] lint fixes
- [x] save the latest cached image in a variable
- [x] use that cached image if there is no new image captured
- [x] fix broken tests  

This change can be seen a little more obviously by setting up the local module with data capture, turning on data capture then turning it back off. The image in the test card should stay on the last captured image.