### PR TITLE
add warning to readme re: which methods work in the data management service

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ On the new component panel, copy and paste the following attribute template into
 
 Remove the "classifications" or "objects" section depending on if your ML model is a classifier or detector.
 
+> [!WARNING]
+> The data management service must be configured to use the `ReadImage` method and _not_ the `GetImages` method! As of June 2025, the former can be identified as originating from the data management service, while the latter cannot.
+
 > [!NOTE]
 > For more information, see [Configure a Machine](https://docs.viam.com/operate/get-started/supported-hardware/#configure-hardware-on-your-machine).
 
@@ -132,6 +135,9 @@ On the new component panel, copy and paste the following attribute template into
     "window_seconds": <time_window_for_capture>
 }
 ```
+
+> [!WARNING]
+> The data management service must be configured to use the `ReadImage` method and _not_ the `GetImages` method! As of June 2025, the former can be identified as originating from the data management service, while the latter cannot.
 
 ### Example configurations
 


### PR DESCRIPTION
These are the two sections that are inlined in the builder when configuring the component. I've already run `viam module update`, and it's showing up alright (though markdown isn't rendered great in the config builder: the warning and the note below it just have square brackets and exclamation points). 