### PR TITLE
RSDK-11254: Capture images in a background goroutine, independent of filter times

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ On the new component panel, copy and paste the following attribute template into
         }
     ],
     "window_seconds": <time_window_for_capture>,
+    "image_frequency": <capture_rate_of_images_in_buffer>,
 }
 ```
 
@@ -57,8 +58,9 @@ The following attributes are available for `viam:camera:filtered-camera` bases:
 | `vision_services` | list | **Required** | A list of 1 or more vision services used for image classifications or detections. |
 | `vision` | string | **Required** | \*\***DEPRECATED**\*\* The vision service used for image classifications or detections. |
 | `window_seconds` | float64 | Optional | The size of the time window (in seconds) during which images are buffered. When a condition is met, a confidence score for a detection/classification exceeds the required confidence score, the buffered images are stored, allowing us to see the photos taken in the N number of seconds preceding the condition being met. |
-| `classifications` | float64 | Optional | \*\***DEPRECATED**\*\* A map of classification labels and the confidence scores required for filtering. Use this if the ML model behind your vision service is a classifier. You can find these labels by testing your vision service. |
-| `objects` | float64 | Optional | \*\***DEPRECATED**\*\* A map of object detection labels and the confidence scores required for filtering. Use this if the ML model behind your vision service is a detector. You can find these labels by testing your vision service. |
+| `image_frequency` | float64 | Optional | the frequency at which to place images into the buffer (in Hz). Default value is 1.0 Hz |
+| `classifications` | float64 | Optional | \*\***DEPRECATED** Use `vision_services`\*\* A map of classification labels and the confidence scores required for filtering. Use this if the ML model behind your vision service is a classifier. You can find these labels by testing your vision service. |
+| `objects` | float64 | Optional | \*\***DEPRECATED** use `vision_services` \*\* A map of object detection labels and the confidence scores required for filtering. Use this if the ML model behind your vision service is a detector. You can find these labels by testing your vision service. |
 
 > [!WARNING]
 > If a vision service has no specified classifications and/or objects, it won't trigger any data capture.
@@ -82,7 +84,8 @@ The following attributes are available for `viam:camera:filtered-camera` bases:
             }
         }
     ],
-    "windowSeconds": 5,
+    "window_seconds": 6,
+    "image_frequency": 0.5,
 }
 ```
 

--- a/cam.go
+++ b/cam.go
@@ -22,6 +22,8 @@ import (
 
 var Model = Family.WithModel("filtered-camera")
 
+const defaultImageFreq = 1.0
+
 type Config struct {
 	Camera string
 	// Deprecated: use VisionServices instead
@@ -157,11 +159,15 @@ func init() {
 			fc.rejectedStats.startTime = time.Now()
 
 			// Initialize the image buffer
-			fc.buf = imagebuffer.NewImageBuffer(newConf.WindowSeconds, newConf.ImageFrequency)
+			imageFreq := newConf.ImageFrequency
+			if imageFreq == 0 {
+				imageFreq = defaultImageFreq
+			}
+			fc.buf = imagebuffer.NewImageBuffer(newConf.WindowSeconds, imageFreq)
 
 			// Initialize background image capture worker
 			fc.backgroundWorkers = utils.NewStoppableWorkerWithTicker(
-				time.Duration(1000.0/newConf.ImageFrequency)*time.Millisecond,
+				time.Duration(1000.0/imageFreq)*time.Millisecond,
 				func(ctx context.Context) {
 					fc.captureImageInBackground(ctx)
 				},

--- a/cam.go
+++ b/cam.go
@@ -369,7 +369,6 @@ func (fc *filteredCamera) images(ctx context.Context, extra map[string]interface
 		}
 		if shouldSend {
 			fc.buf.CacheImages(images)
-			// Return the cached images from the ring buffer
 			fc.buf.Mu.Lock()
 			defer fc.buf.Mu.Unlock()
 

--- a/cam.go
+++ b/cam.go
@@ -63,8 +63,8 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 		return nil, utils.NewConfigValidationError(path, errors.New("cannot specify both vision and vision_services"))
 	}
 
-	if cfg.ImageFrequency <= 0 {
-		return nil, utils.NewConfigValidationError(path, errors.New("image_frequency must be greater than 0"))
+	if cfg.ImageFrequency < 0 {
+		return nil, utils.NewConfigValidationError(path, errors.New("image_frequency cannot be less than 0"))
 	}
 
 	deps := []string{cfg.Camera}

--- a/cam.go
+++ b/cam.go
@@ -355,9 +355,7 @@ func (fc *filteredCamera) images(ctx context.Context, extra map[string]interface
 		return images, meta, err
 	}
 
-	if IsFromDataMgmt(ctx, extra) {
-		fc.buf.AddToBuffer(images, meta, fc.conf.WindowSeconds)
-	} else {
+	if !IsFromDataMgmt(ctx, extra) {
 		return images, meta, nil
 	}
 
@@ -389,7 +387,7 @@ func (fc *filteredCamera) images(ctx context.Context, extra map[string]interface
 		fc.buf.ToSend = fc.buf.ToSend[1:]
 		return x.Imgs, x.Meta, nil
 	}
-	return x.Imgs, x.Meta, nil
+	return nil, meta, data.ErrNoCaptureToStore
 }
 
 func (fc *filteredCamera) shouldSend(ctx context.Context, img image.Image, now time.Time) (bool, error) {

--- a/cam.go
+++ b/cam.go
@@ -319,7 +319,7 @@ func (fc *filteredCamera) captureImageInBackground(ctx context.Context) {
 		return
 	}
 	now := meta.CapturedAt
-	// if we're Within the trigger time still, directly add the images to ToSend buffer
+	// if we're within the trigger time still, directly add the images to ToSend buffer
 	// else then store them in the ring buffer
 	if now.Before(fc.buf.CaptureTill) || now.Equal(fc.buf.CaptureTill) {
 		fc.buf.Mu.Lock()

--- a/cam.go
+++ b/cam.go
@@ -366,6 +366,7 @@ func (fc *filteredCamera) images(ctx context.Context, extra map[string]interface
 			return nil, meta, err
 		}
 		if shouldSend {
+			// this updates the CaptureTill time to be further in the future
 			fc.buf.MarkShouldSend(meta.CapturedAt)
 			fc.buf.CacheImages(images)
 			fc.buf.Mu.Lock()

--- a/cam.go
+++ b/cam.go
@@ -319,13 +319,7 @@ func (fc *filteredCamera) captureImageInBackground(ctx context.Context) {
 		return
 	}
 	now := meta.CapturedAt
-	// if we're within the CaptureTill trigger time still, directly add the images to ToSend buffer
-	// else then store them in the ring buffer
-	if now.Before(fc.buf.GetCaptureTill()) || now.Equal(fc.buf.GetCaptureTill()) {
-		fc.buf.AppendToSend(imagebuffer.CachedData{Imgs: images, Meta: meta})
-	} else {
-		fc.buf.AddToRingBuffer(images, meta)
-	}
+	fc.buf.StoreImages(images, meta, now)
 }
 
 func (fc *filteredCamera) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {

--- a/cam.go
+++ b/cam.go
@@ -456,13 +456,6 @@ func (fc *filteredCamera) shouldSend(ctx context.Context, img image.Image, now t
 			}
 		}
 	}
-	// if we don't inhibit or update CaptureTill with another trigger, check to see if still within
-	// the CaptureTill window
-	if now.Before(fc.buf.CaptureTill) {
-		// send, but don't update captureTill
-		return true, nil
-	}
-
 	if len(fc.otherVisionServices) == 0 {
 		fc.acceptedStats.update("no vision services triggered")
 		fc.logger.Debugf("defaulting to true")

--- a/cam_test.go
+++ b/cam_test.go
@@ -245,7 +245,6 @@ func TestWindow(t *testing.T) {
 	b := time.Now().Add(-1 * time.Second)
 	c := time.Now().Add(-1 * time.Minute)
 
-	// Test the new ring buffer behavior
 	fc.buf.RingBuffer = []imagebuffer.CachedData{
 		{Meta: resource.ResponseMetadata{CapturedAt: a}},
 		{Meta: resource.ResponseMetadata{CapturedAt: b}},

--- a/cam_test.go
+++ b/cam_test.go
@@ -552,7 +552,7 @@ func TestRingBufferTriggerWindows(t *testing.T) {
 	triggerTime1 := baseTime.Add(5 * time.Second)
 	fc.buf.MarkShouldSend(triggerTime1)
 
-	// Should capture images 3, 4, 5, 6 (within window [3, 7])
+	// Should first capture images 3, 4, 5 (images in the before-trigger buffer)
 	expectedFirstTrigger := []time.Time{
 		baseTime.Add(3 * time.Second),
 		baseTime.Add(4 * time.Second),
@@ -570,6 +570,7 @@ func TestRingBufferTriggerWindows(t *testing.T) {
 	for i := 6; i <= 10; i++ {
 		fc.captureImageInBackground(ctx)
 	}
+	// now check that all 5 expected images are in the ToSend buffer
 	test.That(t, len(fc.buf.ToSend), test.ShouldEqual, 5)
 	for i, expected := range expectedFirstTrigger {
 		test.That(t, fc.buf.ToSend[i].Meta.CapturedAt, test.ShouldEqual, expected)
@@ -665,10 +666,12 @@ func TestMultipleTriggerWindows(t *testing.T) {
 	// Now add more images, with additional triggers at 7 and 9
 	fc.captureImageInBackground(ctx) // 6
 	fc.captureImageInBackground(ctx) // 7
+	// Manually trigger at time 7
 	triggerTime2 := baseTime.Add(7 * time.Second)
 	fc.buf.MarkShouldSend(triggerTime2)
 	fc.captureImageInBackground(ctx) // 8
 	fc.captureImageInBackground(ctx) // 9
+	// Manually trigger at time 9
 	triggerTime3 := baseTime.Add(9 * time.Second)
 	fc.buf.MarkShouldSend(triggerTime3)
 	for i := 10; i <= 20; i++ {

--- a/cam_test.go
+++ b/cam_test.go
@@ -662,7 +662,7 @@ func TestMultipleTriggerWindows(t *testing.T) {
 	// Manually trigger at time 5
 	triggerTime1 := baseTime.Add(5 * time.Second)
 	fc.buf.MarkShouldSend(triggerTime1)
-	// Now add images 6-15, with additional triggers at 7 and 9
+	// Now add more images, with additional triggers at 7 and 9
 	fc.captureImageInBackground(ctx) // 6
 	fc.captureImageInBackground(ctx) // 7
 	triggerTime2 := baseTime.Add(7 * time.Second)
@@ -671,7 +671,7 @@ func TestMultipleTriggerWindows(t *testing.T) {
 	fc.captureImageInBackground(ctx) // 9
 	triggerTime3 := baseTime.Add(9 * time.Second)
 	fc.buf.MarkShouldSend(triggerTime3)
-	for i := 10; i <= 15; i++ {
+	for i := 10; i <= 20; i++ {
 		fc.captureImageInBackground(ctx)
 	}
 	// so ToSend should capture [3, 11] and make no repeats
@@ -686,7 +686,9 @@ func TestMultipleTriggerWindows(t *testing.T) {
 		baseTime.Add(10 * time.Second),
 		baseTime.Add(11 * time.Second),
 	}
-
+	for _, tosend := range fc.buf.ToSend {
+		t.Logf("ts: %s\n", tosend.Meta.CapturedAt)
+	}
 	test.That(t, len(fc.buf.ToSend), test.ShouldEqual, 9)
 	for i, expected := range expectedTrigger {
 		test.That(t, fc.buf.ToSend[i].Meta.CapturedAt, test.ShouldEqual, expected)

--- a/cam_test.go
+++ b/cam_test.go
@@ -564,7 +564,7 @@ func TestRingBufferTriggerWindows(t *testing.T) {
 		test.That(t, fc.buf.GetToSendSlice()[i].Meta.CapturedAt, test.ShouldEqual, expected)
 	}
 	// Now add images 6-10 leading up to second trigger, and check if only two more images are added
-	// to the two send buffer
+	// to the ToSend buffer
 	expectedFirstTrigger = append(expectedFirstTrigger, baseTime.Add(6*time.Second))
 	expectedFirstTrigger = append(expectedFirstTrigger, baseTime.Add(7*time.Second))
 	for i := 6; i <= 10; i++ {
@@ -598,7 +598,7 @@ func TestRingBufferTriggerWindows(t *testing.T) {
 		test.That(t, fc.buf.GetToSendSlice()[i].Meta.CapturedAt, test.ShouldEqual, expected)
 	}
 	// Now add images 11 - 15 after trigger, and check if only two more images are added
-	// to the two send buffer
+	// to the ToSend buffer
 	expectedTrigger = append(expectedTrigger, baseTime.Add(11*time.Second))
 	expectedTrigger = append(expectedTrigger, baseTime.Add(12*time.Second))
 	for i := 11; i <= 15; i++ {

--- a/cam_test.go
+++ b/cam_test.go
@@ -686,9 +686,6 @@ func TestMultipleTriggerWindows(t *testing.T) {
 		baseTime.Add(10 * time.Second),
 		baseTime.Add(11 * time.Second),
 	}
-	for _, tosend := range fc.buf.ToSend {
-		t.Logf("ts: %s\n", tosend.Meta.CapturedAt)
-	}
 	test.That(t, len(fc.buf.ToSend), test.ShouldEqual, 9)
 	for i, expected := range expectedTrigger {
 		test.That(t, fc.buf.ToSend[i].Meta.CapturedAt, test.ShouldEqual, expected)

--- a/cam_test.go
+++ b/cam_test.go
@@ -95,14 +95,14 @@ func TestShouldSend(t *testing.T) {
 	test.That(t, res, test.ShouldEqual, true)
 
 	// Reset buffer state to clear CaptureTill
-	fc.buf.CaptureTill = time.Time{}
+	fc.buf.SetCaptureTill(time.Time{})
 
 	res, err = fc.shouldSend(context.Background(), a, time.Now())
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res, test.ShouldEqual, true)
 
 	// Reset buffer state to clear CaptureTill
-	fc.buf.CaptureTill = time.Time{}
+	fc.buf.SetCaptureTill(time.Time{})
 
 	// test wildcard
 
@@ -111,7 +111,7 @@ func TestShouldSend(t *testing.T) {
 	test.That(t, res, test.ShouldEqual, false)
 
 	// Reset buffer state to clear CaptureTill
-	fc.buf.CaptureTill = time.Time{}
+	fc.buf.SetCaptureTill(time.Time{})
 
 	res, err = fc.shouldSend(context.Background(), f, time.Now())
 	test.That(t, err, test.ShouldBeNil)
@@ -121,14 +121,14 @@ func TestShouldSend(t *testing.T) {
 	fc.acceptedObjects[""] = map[string]float64{"*": .8}
 
 	// Reset buffer state to clear CaptureTill
-	fc.buf.CaptureTill = time.Time{}
+	fc.buf.SetCaptureTill(time.Time{})
 
 	res, err = fc.shouldSend(context.Background(), e, time.Now())
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res, test.ShouldEqual, true)
 
 	// Reset buffer state to clear CaptureTill
-	fc.buf.CaptureTill = time.Time{}
+	fc.buf.SetCaptureTill(time.Time{})
 
 	res, err = fc.shouldSend(context.Background(), f, time.Now())
 	test.That(t, err, test.ShouldBeNil)
@@ -141,7 +141,7 @@ func TestShouldSend(t *testing.T) {
 		getDummyVisionService(),
 	}
 	// Reset buffer state to clear CaptureTill
-	fc.buf.CaptureTill = time.Time{}
+	fc.buf.SetCaptureTill(time.Time{})
 
 	res, err = fc.shouldSend(context.Background(), a, time.Now())
 	test.That(t, err, test.ShouldBeNil)
@@ -151,7 +151,7 @@ func TestShouldSend(t *testing.T) {
 	fc.inhibitedClassifications = map[string]map[string]float64{}
 	fc.inhibitedObjects = map[string]map[string]float64{"": {"b": .1}}
 	// Reset buffer state to clear CaptureTill
-	fc.buf.CaptureTill = time.Time{}
+	fc.buf.SetCaptureTill(time.Time{})
 
 	res, err = fc.shouldSend(context.Background(), b, time.Now())
 	test.That(t, err, test.ShouldBeNil)
@@ -162,14 +162,14 @@ func TestShouldSend(t *testing.T) {
 	fc.acceptedObjects = map[string]map[string]float64{"": {"f": .7}}
 
 	// Reset buffer state to clear CaptureTill
-	fc.buf.CaptureTill = time.Time{}
+	fc.buf.SetCaptureTill(time.Time{})
 
 	res, err = fc.shouldSend(context.Background(), b, time.Now())
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, res, test.ShouldEqual, false)
 
 	// Reset buffer state to clear CaptureTill
-	fc.buf.CaptureTill = time.Time{}
+	fc.buf.SetCaptureTill(time.Time{})
 
 	res, err = fc.shouldSend(context.Background(), f, time.Now())
 	test.That(t, err, test.ShouldBeNil)
@@ -182,7 +182,7 @@ func TestShouldSend(t *testing.T) {
 	fc.acceptedClassifications = map[string]map[string]float64{"": {"a": .8}}
 
 	// Reset buffer state to clear CaptureTill
-	fc.buf.CaptureTill = time.Time{}
+	fc.buf.SetCaptureTill(time.Time{})
 
 	res, err = fc.shouldSend(context.Background(), a, time.Now())
 	test.That(t, err, test.ShouldBeNil)
@@ -199,7 +199,7 @@ func TestShouldSend(t *testing.T) {
 		getDummyVisionService(),
 	}
 	// Reset buffer state to clear CaptureTill
-	fc.buf.CaptureTill = time.Time{}
+	fc.buf.SetCaptureTill(time.Time{})
 
 	res, err = fc.shouldSend(context.Background(), b, time.Now())
 	test.That(t, err, test.ShouldBeNil)
@@ -213,7 +213,7 @@ func TestShouldSend(t *testing.T) {
 	// test that image that does not match any classification or object is rejected
 	fc.rejectedStats = imageStats{}
 	// Reset buffer state to clear CaptureTill
-	fc.buf.CaptureTill = time.Time{}
+	fc.buf.SetCaptureTill(time.Time{})
 
 	res, err = fc.shouldSend(context.Background(), d, time.Now())
 	test.That(t, err, test.ShouldBeNil)
@@ -546,7 +546,7 @@ func TestRingBufferTriggerWindows(t *testing.T) {
 		fc.captureImageInBackground(ctx)
 	}
 	// Verify ring buffer contains only the last 4 images (2, 3, 4, 5)
-	test.That(t, len(fc.buf.RingBuffer), test.ShouldEqual, 4)
+	test.That(t, fc.buf.GetRingBufferLength(), test.ShouldEqual, 4)
 
 	// Manually trigger at time 5, which should capture images 3, 4, 5, 6, 7 (within 2 second window [3, 7])
 	triggerTime1 := baseTime.Add(5 * time.Second)
@@ -559,9 +559,9 @@ func TestRingBufferTriggerWindows(t *testing.T) {
 		baseTime.Add(5 * time.Second),
 	}
 
-	test.That(t, len(fc.buf.ToSend), test.ShouldEqual, 3)
+	test.That(t, fc.buf.GetToSendLength(), test.ShouldEqual, 3)
 	for i, expected := range expectedFirstTrigger {
-		test.That(t, fc.buf.ToSend[i].Meta.CapturedAt, test.ShouldEqual, expected)
+		test.That(t, fc.buf.GetToSendSlice()[i].Meta.CapturedAt, test.ShouldEqual, expected)
 	}
 	// Now add images 6-10 leading up to second trigger, and check if only two more images are added
 	// to the two send buffer
@@ -571,16 +571,16 @@ func TestRingBufferTriggerWindows(t *testing.T) {
 		fc.captureImageInBackground(ctx)
 	}
 	// now check that all 5 expected images are in the ToSend buffer
-	test.That(t, len(fc.buf.ToSend), test.ShouldEqual, 5)
+	test.That(t, fc.buf.GetToSendLength(), test.ShouldEqual, 5)
 	for i, expected := range expectedFirstTrigger {
-		test.That(t, fc.buf.ToSend[i].Meta.CapturedAt, test.ShouldEqual, expected)
+		test.That(t, fc.buf.GetToSendSlice()[i].Meta.CapturedAt, test.ShouldEqual, expected)
 	}
 
 	// Clear ToSend to prepare for second trigger
-	fc.buf.ToSend = []imagebuffer.CachedData{}
-	test.That(t, len(fc.buf.ToSend), test.ShouldEqual, 0)
+	fc.buf.ClearToSend()
+	test.That(t, fc.buf.GetToSendLength(), test.ShouldEqual, 0)
 	// Verify ring buffer contains only the last 4 images (7, 8, 9, 10)
-	test.That(t, len(fc.buf.RingBuffer), test.ShouldEqual, 4)
+	test.That(t, fc.buf.GetRingBufferLength(), test.ShouldEqual, 4)
 
 	// Manually trigger at time 10, which should capture images 8, 9, 10
 	triggerTime2 := baseTime.Add(10 * time.Second)
@@ -593,9 +593,9 @@ func TestRingBufferTriggerWindows(t *testing.T) {
 		baseTime.Add(10 * time.Second),
 	}
 
-	test.That(t, len(fc.buf.ToSend), test.ShouldEqual, 3)
+	test.That(t, fc.buf.GetToSendLength(), test.ShouldEqual, 3)
 	for i, expected := range expectedTrigger {
-		test.That(t, fc.buf.ToSend[i].Meta.CapturedAt, test.ShouldEqual, expected)
+		test.That(t, fc.buf.GetToSendSlice()[i].Meta.CapturedAt, test.ShouldEqual, expected)
 	}
 	// Now add images 11 - 15 after trigger, and check if only two more images are added
 	// to the two send buffer
@@ -604,9 +604,9 @@ func TestRingBufferTriggerWindows(t *testing.T) {
 	for i := 11; i <= 15; i++ {
 		fc.captureImageInBackground(ctx)
 	}
-	test.That(t, len(fc.buf.ToSend), test.ShouldEqual, 5)
+	test.That(t, fc.buf.GetToSendLength(), test.ShouldEqual, 5)
 	for i, expected := range expectedTrigger {
-		test.That(t, fc.buf.ToSend[i].Meta.CapturedAt, test.ShouldEqual, expected)
+		test.That(t, fc.buf.GetToSendSlice()[i].Meta.CapturedAt, test.ShouldEqual, expected)
 	}
 }
 
@@ -689,8 +689,8 @@ func TestMultipleTriggerWindows(t *testing.T) {
 		baseTime.Add(10 * time.Second),
 		baseTime.Add(11 * time.Second),
 	}
-	test.That(t, len(fc.buf.ToSend), test.ShouldEqual, 9)
+	test.That(t, fc.buf.GetToSendLength(), test.ShouldEqual, 9)
 	for i, expected := range expectedTrigger {
-		test.That(t, fc.buf.ToSend[i].Meta.CapturedAt, test.ShouldEqual, expected)
+		test.That(t, fc.buf.GetToSendSlice()[i].Meta.CapturedAt, test.ShouldEqual, expected)
 	}
 }

--- a/cam_test.go
+++ b/cam_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	imagebuffer "github.com/viam-modules/filtered_camera/image_buffer"
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/data"
 	"go.viam.com/rdk/logging"
@@ -17,6 +16,8 @@ import (
 	"go.viam.com/rdk/utils"
 	"go.viam.com/rdk/vision/classification"
 	"go.viam.com/rdk/vision/objectdetection"
+
+	imagebuffer "github.com/viam-modules/filtered_camera/image_buffer"
 
 	"go.viam.com/test"
 )
@@ -185,6 +186,7 @@ func TestValidate(t *testing.T) {
 		Classifications: map[string]float64{"a": .8},
 		Objects:         map[string]float64{"b": .8},
 		WindowSeconds:   10,
+		ImageFrequency:  1.0,
 	}
 
 	res, err := conf.Validate(".")

--- a/conditional_camera/conditional_cam.go
+++ b/conditional_camera/conditional_cam.go
@@ -41,7 +41,7 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "filter_service")
 	}
 
-	if cfg.ImageFrequency <= 0 {
+	if cfg.ImageFrequency < 0 {
 		return nil, utils.NewConfigValidationError(path, errors.New("image_frequency must be greater than 0"))
 	}
 

--- a/conditional_camera/conditional_cam.go
+++ b/conditional_camera/conditional_cam.go
@@ -121,7 +121,9 @@ func (cc *conditionalCamera) images(ctx context.Context, extra map[string]interf
 		return images, meta, err
 	}
 
-	if !filtered_camera.IsFromDataMgmt(ctx, extra) {
+	if filtered_camera.IsFromDataMgmt(ctx, extra) {
+		cc.buf.AddToRingBuffer(images, meta)
+	} else {
 		return images, meta, nil
 	}
 
@@ -138,7 +140,6 @@ func (cc *conditionalCamera) images(ctx context.Context, extra map[string]interf
 	cc.buf.Mu.Lock()
 	defer cc.buf.Mu.Unlock()
 
-	cc.buf.AddToBuffer_inlock(images, meta)
 
 	if len(cc.buf.ToSend) > 0 {
 		x := cc.buf.ToSend[0]

--- a/conditional_camera/conditional_cam.go
+++ b/conditional_camera/conditional_cam.go
@@ -154,18 +154,7 @@ func (cc *conditionalCamera) shouldSend(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-
-	// TODO: Make this configurable with "result" as default
-	if ans["result"].(bool) {
-		if time.Now().Before(cc.buf.CaptureTill) {
-			// send, but don't update captureTill
-			return true, nil
-		}
-		cc.buf.MarkShouldSend(time.Now())
-		return true, nil
-	}
-
-	return false, nil
+	return ans["result"].(bool), nil
 }
 
 func (cc *conditionalCamera) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {

--- a/conditional_camera/conditional_cam.go
+++ b/conditional_camera/conditional_cam.go
@@ -5,7 +5,6 @@ package conditional_camera
 
 import (
 	"context"
-	"time"
 
 	"github.com/pkg/errors"
 	imagebuffer "github.com/viam-modules/filtered_camera/image_buffer"

--- a/conditional_camera/conditional_cam.go
+++ b/conditional_camera/conditional_cam.go
@@ -136,13 +136,7 @@ func (cc *conditionalCamera) images(ctx context.Context, extra map[string]interf
 		}
 	}
 
-	cc.buf.Mu.Lock()
-	defer cc.buf.Mu.Unlock()
-
-
-	if len(cc.buf.ToSend) > 0 {
-		x := cc.buf.ToSend[0]
-		cc.buf.ToSend = cc.buf.ToSend[1:]
+	if x, ok := cc.buf.PopFirstToSend(); ok {
 		return x.Imgs, x.Meta, nil
 	}
 	return nil, meta, data.ErrNoCaptureToStore

--- a/image_buffer/image_buffer.go
+++ b/image_buffer/image_buffer.go
@@ -98,14 +98,8 @@ func (ib *ImageBuffer) CacheImages(images []camera.NamedImage) {
 	}
 }
 
-// GetCaptureTill returns the current captureTill time
-func (ib *ImageBuffer) GetCaptureTill() time.Time {
-	ib.mu.Lock()
-	defer ib.mu.Unlock()
-	return ib.captureTill
-}
-
 // SetCaptureTill sets the captureTill time
+// This method is only used for testing purposes in cam_test.go
 func (ib *ImageBuffer) SetCaptureTill(t time.Time) {
 	ib.mu.Lock()
 	defer ib.mu.Unlock()
@@ -131,21 +125,8 @@ func (ib *ImageBuffer) PopFirstToSend() (CachedData, bool) {
 	return x, true
 }
 
-// AppendToSend appends a single CachedData to the toSend slice
-func (ib *ImageBuffer) AppendToSend(data CachedData) {
-	ib.mu.Lock()
-	defer ib.mu.Unlock()
-	ib.toSend = append(ib.toSend, data)
-}
-
-// AppendToSendSlice appends a slice of CachedData to the toSend slice
-func (ib *ImageBuffer) AppendToSendSlice(data []CachedData) {
-	ib.mu.Lock()
-	defer ib.mu.Unlock()
-	ib.toSend = append(ib.toSend, data...)
-}
-
 // ClearToSend clears the toSend slice
+// Only used for testing purposes
 func (ib *ImageBuffer) ClearToSend() {
 	ib.mu.Lock()
 	defer ib.mu.Unlock()
@@ -153,6 +134,7 @@ func (ib *ImageBuffer) ClearToSend() {
 }
 
 // GetRingBufferLength returns the length of the ringBuffer slice
+// Only used for testing purposes
 func (ib *ImageBuffer) GetRingBufferLength() int {
 	ib.mu.Lock()
 	defer ib.mu.Unlock()
@@ -160,6 +142,7 @@ func (ib *ImageBuffer) GetRingBufferLength() int {
 }
 
 // GetToSendSlice returns a copy of the toSend slice for testing
+// Only used for testing purposes
 func (ib *ImageBuffer) GetToSendSlice() []CachedData {
 	ib.mu.Lock()
 	defer ib.mu.Unlock()

--- a/image_buffer/image_buffer.go
+++ b/image_buffer/image_buffer.go
@@ -60,7 +60,6 @@ func (ib *ImageBuffer) CleanBuffer_inlock() {
 		if ib.Buffer[0].Meta.CapturedAt.After(early) {
 			return
 		}
-		ib.recentImages = ib.recentImages[1:]
 	}
 }
 
@@ -114,18 +113,4 @@ func (ib *ImageBuffer) CacheImages(images []camera.NamedImage) {
 			CapturedAt: time.Now(),
 		},
 	}
-	ib.recentImages = []CachedData{}
-}
-
-// Returns the oldest CachedData we're supposed to send. Returns nil if the buffer is empty.
-func (ib *ImageBuffer) GetCachedData() *CachedData {
-	ib.mu.Lock()
-	defer ib.mu.Unlock()
-
-	if len(ib.toSend) == 0 {
-		return nil
-	}
-	return_value := ib.toSend[0]
-	ib.toSend = ib.toSend[1:]
-	return &return_value
 }

--- a/image_buffer/image_buffer.go
+++ b/image_buffer/image_buffer.go
@@ -14,33 +14,33 @@ type CachedData struct {
 }
 
 type ImageBuffer struct {
-	Mu             sync.Mutex
-	RingBuffer     []CachedData
-	ToSend         []CachedData
-	CaptureTill    time.Time
-	LastCached     CachedData
-	WindowSeconds  int
-	ImageFrequency float64
+	mu             sync.Mutex
+	ringBuffer     []CachedData
+	toSend         []CachedData
+	captureTill    time.Time
+	lastCached     CachedData
+	windowSeconds  int
+	imageFrequency float64
 }
 
 func NewImageBuffer(windowSeconds int, imageFrequency float64) *ImageBuffer {
 	return &ImageBuffer{
-		RingBuffer:     []CachedData{},
-		ToSend:         []CachedData{},
-		WindowSeconds:  windowSeconds,
-		ImageFrequency: imageFrequency,
+		ringBuffer:     []CachedData{},
+		toSend:         []CachedData{},
+		windowSeconds:  windowSeconds,
+		imageFrequency: imageFrequency,
 	}
 }
 
 func (ib *ImageBuffer) windowDuration() time.Duration {
-	return time.Second * time.Duration(ib.WindowSeconds)
+	return time.Second * time.Duration(ib.windowSeconds)
 }
 
 func (ib *ImageBuffer) MarkShouldSend(now time.Time) {
-	ib.Mu.Lock()
-	defer ib.Mu.Unlock()
+	ib.mu.Lock()
+	defer ib.mu.Unlock()
 
-	ib.CaptureTill = now.Add(ib.windowDuration())
+	ib.captureTill = now.Add(ib.windowDuration())
 
 	// Send images from the ring buffer and continue collecting for windowDuration
 	triggerTime := now
@@ -48,13 +48,13 @@ func (ib *ImageBuffer) MarkShouldSend(now time.Time) {
 
 	// Create a map of existing timestamps in ToSend for O(1) lookup
 	existingTimes := make(map[int64]bool)
-	for _, existing := range ib.ToSend {
+	for _, existing := range ib.toSend {
 		existingTimes[existing.Meta.CapturedAt.UnixNano()] = true
 	}
 
 	// Add images from the ring buffer that are within the window
 	windowDuration := ib.windowDuration()
-	for _, cached := range ib.RingBuffer {
+	for _, cached := range ib.ringBuffer {
 		timeDiff := triggerTime.Sub(cached.Meta.CapturedAt)
 		// Include images within windowSeconds before and after trigger
 		if timeDiff >= -windowDuration && timeDiff <= windowDuration {
@@ -66,33 +66,108 @@ func (ib *ImageBuffer) MarkShouldSend(now time.Time) {
 	}
 
 	// Add the images to send
-	ib.ToSend = append(ib.ToSend, imagesToSend...)
+	ib.toSend = append(ib.toSend, imagesToSend...)
 }
 
 func (ib *ImageBuffer) AddToRingBuffer(imgs []camera.NamedImage, meta resource.ResponseMetadata) {
-	ib.Mu.Lock()
-	defer ib.Mu.Unlock()
+	ib.mu.Lock()
+	defer ib.mu.Unlock()
 
-	ib.RingBuffer = append(ib.RingBuffer, CachedData{imgs, meta})
+	ib.ringBuffer = append(ib.ringBuffer, CachedData{imgs, meta})
 
 	// Calculate the maximum number of images to keep in the ring buffer
 	// Keep images for 2 * windowSeconds (before and after trigger)
-	maxImages := int(2 * float64(ib.WindowSeconds) * ib.ImageFrequency)
+	maxImages := int(2 * float64(ib.windowSeconds) * ib.imageFrequency)
 
 	// Remove oldest images if we exceed the max
-	if len(ib.RingBuffer) > maxImages {
-		ib.RingBuffer = ib.RingBuffer[len(ib.RingBuffer)-maxImages:]
+	if len(ib.ringBuffer) > maxImages {
+		ib.ringBuffer = ib.ringBuffer[len(ib.ringBuffer)-maxImages:]
 	}
 }
 
 func (ib *ImageBuffer) CacheImages(images []camera.NamedImage) {
-	ib.Mu.Lock()
-	defer ib.Mu.Unlock()
+	ib.mu.Lock()
+	defer ib.mu.Unlock()
 
-	ib.LastCached = CachedData{
+	ib.lastCached = CachedData{
 		Imgs: images,
 		Meta: resource.ResponseMetadata{
 			CapturedAt: time.Now(),
 		},
 	}
+}
+
+// GetCaptureTill returns the current captureTill time
+func (ib *ImageBuffer) GetCaptureTill() time.Time {
+	ib.mu.Lock()
+	defer ib.mu.Unlock()
+	return ib.captureTill
+}
+
+// SetCaptureTill sets the captureTill time
+func (ib *ImageBuffer) SetCaptureTill(t time.Time) {
+	ib.mu.Lock()
+	defer ib.mu.Unlock()
+	ib.captureTill = t
+}
+
+// GetToSendLength returns the length of the toSend slice
+func (ib *ImageBuffer) GetToSendLength() int {
+	ib.mu.Lock()
+	defer ib.mu.Unlock()
+	return len(ib.toSend)
+}
+
+// PopFirstToSend removes and returns the first element from toSend slice
+func (ib *ImageBuffer) PopFirstToSend() (CachedData, bool) {
+	ib.mu.Lock()
+	defer ib.mu.Unlock()
+	if len(ib.toSend) == 0 {
+		return CachedData{}, false
+	}
+	x := ib.toSend[0]
+	ib.toSend = ib.toSend[1:]
+	return x, true
+}
+
+// AppendToSend appends a single CachedData to the toSend slice
+func (ib *ImageBuffer) AppendToSend(data CachedData) {
+	ib.mu.Lock()
+	defer ib.mu.Unlock()
+	ib.toSend = append(ib.toSend, data)
+}
+
+// AppendToSendSlice appends a slice of CachedData to the toSend slice
+func (ib *ImageBuffer) AppendToSendSlice(data []CachedData) {
+	ib.mu.Lock()
+	defer ib.mu.Unlock()
+	ib.toSend = append(ib.toSend, data...)
+}
+
+// ClearToSend clears the toSend slice
+func (ib *ImageBuffer) ClearToSend() {
+	ib.mu.Lock()
+	defer ib.mu.Unlock()
+	ib.toSend = []CachedData{}
+}
+
+// GetRingBufferLength returns the length of the ringBuffer slice
+func (ib *ImageBuffer) GetRingBufferLength() int {
+	ib.mu.Lock()
+	defer ib.mu.Unlock()
+	return len(ib.ringBuffer)
+}
+
+// GetToSendSlice returns a copy of the toSend slice for testing
+func (ib *ImageBuffer) GetToSendSlice() []CachedData {
+	ib.mu.Lock()
+	defer ib.mu.Unlock()
+	return append([]CachedData{}, ib.toSend...)
+}
+
+// SetRingBufferForTesting allows tests to directly set the ring buffer contents
+func (ib *ImageBuffer) SetRingBufferForTesting(data []CachedData) {
+	ib.mu.Lock()
+	defer ib.mu.Unlock()
+	ib.ringBuffer = data
 }

--- a/image_buffer/image_buffer.go
+++ b/image_buffer/image_buffer.go
@@ -166,13 +166,6 @@ func (ib *ImageBuffer) GetToSendSlice() []CachedData {
 	return append([]CachedData{}, ib.toSend...)
 }
 
-// SetRingBufferForTesting allows tests to directly set the ring buffer contents
-func (ib *ImageBuffer) SetRingBufferForTesting(data []CachedData) {
-	ib.mu.Lock()
-	defer ib.mu.Unlock()
-	ib.ringBuffer = data
-}
-
 // StoreImages intelligently stores images either in ToSend buffer (if within CaptureTill time)
 // or in the RingBuffer (if outside CaptureTill time)
 func (ib *ImageBuffer) StoreImages(images []camera.NamedImage, meta resource.ResponseMetadata, now time.Time) {

--- a/image_buffer/image_buffer.go
+++ b/image_buffer/image_buffer.go
@@ -79,7 +79,17 @@ func (ib *ImageBuffer) MarkShouldSend(now time.Time) {
 		timeDiff := triggerTime.Sub(cached.Meta.CapturedAt)
 		// Include images within windowSeconds before and after trigger
 		if timeDiff >= -windowDuration && timeDiff <= windowDuration {
-			imagesToSend = append(imagesToSend, cached)
+			// Check if this image is already in ToSend to avoid duplicates
+			found := false
+			for _, existing := range ib.ToSend {
+				if existing.Meta.CapturedAt.Equal(cached.Meta.CapturedAt) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				imagesToSend = append(imagesToSend, cached)
+			}
 		}
 	}
 

--- a/image_buffer/image_buffer_test.go
+++ b/image_buffer/image_buffer_test.go
@@ -20,11 +20,11 @@ func TestWindow(t *testing.T) {
 	// Initialize the image buffer
 	buf := NewImageBuffer(10, 1.0)
 
-	buf.SetRingBufferForTesting([]CachedData{
+	buf.ringBuffer = []CachedData{
 		{Meta: resource.ResponseMetadata{CapturedAt: a}},
 		{Meta: resource.ResponseMetadata{CapturedAt: b}},
 		{Meta: resource.ResponseMetadata{CapturedAt: c}},
-	})
+	}
 
 	buf.MarkShouldSend(time.Now())
 
@@ -35,11 +35,11 @@ func TestWindow(t *testing.T) {
 	test.That(t, b, test.ShouldEqual, toSendSlice[1].Meta.CapturedAt)
 
 	// Reset for second test
-	buf.SetRingBufferForTesting([]CachedData{
+	buf.ringBuffer = []CachedData{
 		{Meta: resource.ResponseMetadata{CapturedAt: c}},
 		{Meta: resource.ResponseMetadata{CapturedAt: b}},
 		{Meta: resource.ResponseMetadata{CapturedAt: a}},
-	})
+	}
 	buf.ClearToSend()
 
 	buf.MarkShouldSend(time.Now())

--- a/image_buffer/image_buffer_test.go
+++ b/image_buffer/image_buffer_test.go
@@ -20,33 +20,35 @@ func TestWindow(t *testing.T) {
 	// Initialize the image buffer
 	buf := NewImageBuffer(10, 1.0)
 
-	buf.RingBuffer = []CachedData{
+	buf.SetRingBufferForTesting([]CachedData{
 		{Meta: resource.ResponseMetadata{CapturedAt: a}},
 		{Meta: resource.ResponseMetadata{CapturedAt: b}},
 		{Meta: resource.ResponseMetadata{CapturedAt: c}},
-	}
+	})
 
 	buf.MarkShouldSend(time.Now())
 
 	// With the new implementation, we expect images within the window to be sent
-	test.That(t, len(buf.ToSend), test.ShouldEqual, 2)
-	test.That(t, a, test.ShouldEqual, buf.ToSend[0].Meta.CapturedAt)
-	test.That(t, b, test.ShouldEqual, buf.ToSend[1].Meta.CapturedAt)
+	test.That(t, buf.GetToSendLength(), test.ShouldEqual, 2)
+	toSendSlice := buf.GetToSendSlice()
+	test.That(t, a, test.ShouldEqual, toSendSlice[0].Meta.CapturedAt)
+	test.That(t, b, test.ShouldEqual, toSendSlice[1].Meta.CapturedAt)
 
 	// Reset for second test
-	buf.RingBuffer = []CachedData{
+	buf.SetRingBufferForTesting([]CachedData{
 		{Meta: resource.ResponseMetadata{CapturedAt: c}},
 		{Meta: resource.ResponseMetadata{CapturedAt: b}},
 		{Meta: resource.ResponseMetadata{CapturedAt: a}},
-	}
-	buf.ToSend = []CachedData{}
+	})
+	buf.ClearToSend()
 
 	buf.MarkShouldSend(time.Now())
 
 	// Test that the ring buffer still contains images (not cleared like old Buffer)
-	test.That(t, len(buf.RingBuffer), test.ShouldEqual, 3)
-	test.That(t, len(buf.ToSend), test.ShouldEqual, 2)
-	test.That(t, b, test.ShouldEqual, buf.ToSend[0].Meta.CapturedAt)
-	test.That(t, a, test.ShouldEqual, buf.ToSend[1].Meta.CapturedAt)
+	test.That(t, buf.GetRingBufferLength(), test.ShouldEqual, 3)
+	test.That(t, buf.GetToSendLength(), test.ShouldEqual, 2)
+	toSendSlice = buf.GetToSendSlice()
+	test.That(t, b, test.ShouldEqual, toSendSlice[0].Meta.CapturedAt)
+	test.That(t, a, test.ShouldEqual, toSendSlice[1].Meta.CapturedAt)
 
 }


### PR DESCRIPTION
We encountered situations where the triggers were taking a long time, and delaying the rate at which the filtered_camera could collect data.

  Key Changes Made:
  - Added image_frequency config parameter - Now accepts a frequency in Hz for background image capture
  - Implemented background goroutine - Uses StoppableWorkers to continuously capture images at the specified frequency and either sends to the ring buffer or directly to the ToSend buffer
  - Updated images() method. Now returns cached images from the ring buffer when shouldSend is true

  How It Works:

  - Background Routine: Runs continuously at image_frequency Hz, capturing images from the underlying camera and storing them in the ring buffer (or sending them ToSend) regardless of filter results
  - Filter Evaluation: The main images() method still evaluates filters at the data manager's cadence
  - Image Delivery: When filters pass (shouldSend is true), the system returns cached images from the ring buffer instead of the current image (and preservers the order in which images arrive)

  Benefits:

  - Decoupled capture from processing: Image capture happens at the desired frequency regardless of filter processing time
  - Consistent frame rate: The ring buffer ensures images are captured at exactly image_frequency Hz. Filter evaluation can take longer without affecting the capture rate
  - Maintains existing API: The changes are backward compatible with existing configurations