### PR TITLE
[RSDK-11657] Add Timestamps when ToSend buffer is empty, but within Capture Window

### DIFF
--- a/cam.go
+++ b/cam.go
@@ -395,7 +395,9 @@ func (fc *filteredCamera) images(ctx context.Context, extra map[string]interface
 			return bufferedImages, bufferedMeta, nil
 		}
 		// If no buffered images, return current image (we're in capture mode)
-		return images, meta, nil
+		// Apply timestamp to current images for consistency
+		timestampedImages := imagebuffer.TimestampImagesToNames(images, meta)
+		return timestampedImages, meta, nil
 	}
 
 	if fc.conf.Debug {

--- a/cam_test.go
+++ b/cam_test.go
@@ -1325,7 +1325,7 @@ func TestNoDuplicateImagesAcrossGetImagesCalls(t *testing.T) {
 	// Track all images returned across multiple GetImages() calls
 	allReturnedImages := make(map[string]int) // image name -> count
 
-	// First GetImages() call - should trigger and return historical images (3 from windows before)
+	// First GetImages() call - should trigger and return historical images (15 from windows before)
 	images1, _, err1 := fc.Images(ctx, map[string]interface{}{data.FromDMString: true})
 	test.That(t, err1, test.ShouldBeNil)
 	test.That(t, len(images1), test.ShouldEqual, 15)

--- a/image_buffer/image_buffer.go
+++ b/image_buffer/image_buffer.go
@@ -92,11 +92,8 @@ func (ib *ImageBuffer) MarkShouldSend(triggerTime time.Time) {
 			// Check if this image is already in ToSend to avoid duplicates
 			if !existingTimes[cached.Meta.CapturedAt.UnixNano()] {
 				imagesToSend = append(imagesToSend, cached)
-				// Don't add to remaining buffer - this image will be sent and should not be reused
-			} else {
-				// Already in ToSend, keep in ring buffer for potential future windows
-				remainingRingBuffer = append(remainingRingBuffer, cached)
 			}
+			// if its a duplicate, then discard it
 		} else {
 			// Outside capture window, keep in ring buffer
 			remainingRingBuffer = append(remainingRingBuffer, cached)

--- a/image_buffer/image_buffer.go
+++ b/image_buffer/image_buffer.go
@@ -160,7 +160,7 @@ func (ib *ImageBuffer) PopFirstToSend() (CachedData, bool) {
 	ib.toSend = ib.toSend[1:]
 
 	// Apply timestamp naming to the images
-	x.Imgs = timestampImagesToNames(x.Imgs, x.Meta)
+	x.Imgs = TimestampImagesToNames(x.Imgs, x.Meta)
 
 	if ib.debug {
 		remainingLen := len(ib.toSend)
@@ -172,8 +172,8 @@ func (ib *ImageBuffer) PopFirstToSend() (CachedData, bool) {
 	return x, true
 }
 
-// timestampImagesToNames converts images to have timestamp-based names in format "[timestamp]_[original_name]"
-func timestampImagesToNames(images []camera.NamedImage, meta resource.ResponseMetadata) []camera.NamedImage {
+// TimestampImagesToNames converts images to have timestamp-based names in format "[timestamp]_[original_name]"
+func TimestampImagesToNames(images []camera.NamedImage, meta resource.ResponseMetadata) []camera.NamedImage {
 	result := make([]camera.NamedImage, len(images))
 	for i, img := range images {
 		result[i] = img // Copy the image
@@ -209,7 +209,7 @@ func (ib *ImageBuffer) PopAllToSend() ([]camera.NamedImage, resource.ResponseMet
 
 	for i, cached := range ib.toSend {
 		// Apply timestamp to each image in this cached data
-		timestampedImages := timestampImagesToNames(cached.Imgs, cached.Meta)
+		timestampedImages := TimestampImagesToNames(cached.Imgs, cached.Meta)
 		allImages = append(allImages, timestampedImages...)
 
 		// Use the earliest timestamp as the metadata for the batch

--- a/image_buffer/image_buffer_test.go
+++ b/image_buffer/image_buffer_test.go
@@ -46,8 +46,8 @@ func TestWindow(t *testing.T) {
 
 	buf.MarkShouldSend(time.Now())
 
-	// Test that the ring buffer still contains images (not cleared like old Buffer)
-	test.That(t, buf.GetRingBufferLength(), test.ShouldEqual, 3)
+	// Test that the ring buffer now only contains images that were NOT sent (c was outside window)
+	test.That(t, buf.GetRingBufferLength(), test.ShouldEqual, 1)
 	test.That(t, buf.GetToSendLength(), test.ShouldEqual, 2)
 	toSendSlice = buf.GetToSendSlice()
 	test.That(t, b, test.ShouldEqual, toSendSlice[0].Meta.CapturedAt)
@@ -85,8 +85,8 @@ func TestWindowBoundaries(t *testing.T) {
 
 	buf.MarkShouldSend(time.Now())
 
-	// Test that the ring buffer still contains images (not cleared like old Buffer)
-	test.That(t, buf.GetRingBufferLength(), test.ShouldEqual, 3)
+	// Test that the ring buffer now only contains images that were NOT sent (c was outside window)
+	test.That(t, buf.GetRingBufferLength(), test.ShouldEqual, 1)
 	test.That(t, buf.GetToSendLength(), test.ShouldEqual, 2)
 	toSendSlice = buf.GetToSendSlice()
 	test.That(t, b, test.ShouldEqual, toSendSlice[0].Meta.CapturedAt)


### PR DESCRIPTION

Two bug fixes:
- Edge condition where GetImages was calling for data capture, but the ToSend buffer was empty. 

When this happens,  GetImages directly returns the images from the underlying camera to data capture, but it wasn't appending the timestamps like when to gets the images from ToSend. This fixes the bug such that images returned directly from the underlying camera also get their timestamp information pre-pended 

- Bug where GetImages would return duplicate images from the Ring Buffer to ToSend. 

This would happen when the window was long, and new windows would be created, and the same images would be copied from the ring buffer into the ToSend buffer. Now images are removed from Ring Buffer when they are being copied from ToSend, and so the danger of duplication doesn't happen