### PR TITLE
[RSDK-13173] dont cache annotations, just upload for trigger image only

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The filtered camera uses a background worker that continuously captures images f
 
 When images are captured and buffered for data management, each image receives a timestamp-based name in the format `[timestamp]_[original_name]` to preserve capture timing information and ensure chronological ordering during data sync.
 
-**Annotations**: When a trigger condition is met, the image that triggered the capture includes the detection or classification annotations (bounding boxes or classification labels) that caused the trigger. Buffered images from before and after the trigger do not include annotations—only the trigger image itself is annotated. This allows you to easily identify which image in a capture sequence was the one that met your filter criteria.
+**Annotations**: When a trigger condition is met, the image that triggered the capture includes the detection or classification annotations (bounding boxes or classification labels) that caused the trigger. Buffered images from before and after the trigger do not include annotations, only the trigger image itself is annotated. This allows you to easily identify which image in a capture sequence was the one that met your filter criteria.
 
 To add the filtered camera to your machine, navigate to the **CONFIGURE** tab of your machine’s page in [the Viam app](https://app.viam.com/).
 Add `camera` / `filtered-camera` to your machine.

--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ The filtered camera uses a background worker that continuously captures images f
 
 When images are captured and buffered for data management, each image receives a timestamp-based name in the format `[timestamp]_[original_name]` to preserve capture timing information and ensure chronological ordering during data sync.
 
+**Annotations**: When a trigger condition is met, the image that triggered the capture includes the detection or classification annotations (bounding boxes or classification labels) that caused the trigger. Buffered images from before and after the trigger do not include annotations—only the trigger image itself is annotated. This allows you to easily identify which image in a capture sequence was the one that met your filter criteria.
+
 To add the filtered camera to your machine, navigate to the **CONFIGURE** tab of your machine’s page in [the Viam app](https://app.viam.com/).
 Add `camera` / `filtered-camera` to your machine.
 
-> [!NOTE]  
-> For a tutorial on filtering data with this module, see [Selectively capture data using filtered-camera](https:docs.viam.com/tutorials/projects/filtered-camera/).
+> [!NOTE]
+> For a tutorial on filtering data with this module, see [Selectively capture data using filtered-camera](https://docs.viam.com/tutorials/projects/filtered-camera/).
 
 ## Releasing -rc and production versions
 
@@ -98,6 +100,27 @@ The following attributes are available for `viam:camera:filtered-camera` bases:
 
 > [!WARNING]
 > If a vision service has no specified classifications and/or objects, it won't trigger any data capture.
+
+> [!TIP]
+> You can use `"*"` as a wildcard label to match any classification or detection above the specified confidence threshold. For example, `"classifications": {"*": 0.8}` will trigger on any classification with confidence above 0.8.
+
+### Statistics
+
+The filtered camera tracks statistics about accepted and rejected images. You can retrieve these statistics by calling `DoCommand` on the camera, which returns:
+
+```json
+{
+    "accepted": {
+        "total": 42,
+        "vision": {"person": 30, "car": 12}
+    },
+    "rejected": {
+        "total": 100,
+        "vision": {"no vision services triggered": 100}
+    },
+    "start_time": "Mon, 15 Jan 2024 10:30:00 UTC"
+}
+```
 
 ### Example configurations
 

--- a/cam.go
+++ b/cam.go
@@ -425,7 +425,7 @@ func (fc *filteredCamera) images(ctx context.Context, filterSourceNames []string
 		img.Annotations.Classifications = annotations.Classifications
 		if shouldSend {
 			// this updates the CaptureTill time to be further in the future
-			fc.buf.MarkShouldSend(meta.CapturedAt, annotations)
+			fc.buf.MarkShouldSend(meta.CapturedAt)
 
 			fc.buf.StoreImages([]camera.NamedImage{img}, meta, meta.CapturedAt)
 

--- a/cam_test.go
+++ b/cam_test.go
@@ -570,10 +570,16 @@ func TestImagesWithBufferedImages(t *testing.T) {
 		test.That(t, strings.Contains(res[i].SourceName, "_buffered_img_"), test.ShouldBeTrue)
 		// Verify timestamps match expected capture times
 		assertTimestampsMatch(t, res[i].SourceName, expectedTimes[i])
+		// Buffered images should NOT have annotations
+		test.That(t, len(res[i].Annotations.BoundingBoxes), test.ShouldEqual, 0)
+		test.That(t, len(res[i].Annotations.Classifications), test.ShouldEqual, 0)
 	}
 
 	// Last one is the annotated trigger image
 	test.That(t, strings.Contains(res[3].SourceName, "_trigger_img"), test.ShouldBeTrue)
+	// Trigger image SHOULD have classification annotations
+	test.That(t, len(res[3].Annotations.Classifications), test.ShouldBeGreaterThan, 0)
+	test.That(t, res[3].Annotations.Classifications[0].Label, test.ShouldEqual, "a")
 
 	test.That(t, meta, test.ShouldNotBeNil)
 }

--- a/cam_test.go
+++ b/cam_test.go
@@ -720,7 +720,7 @@ func TestRingBufferTriggerWindows(t *testing.T) {
 
 	// Manually trigger at time 5, which should capture images 3, 4, 5, 6, 7 (within 2 second window [3, 7])
 	triggerTime1 := baseTime.Add(5 * time.Second)
-	fc.buf.MarkShouldSend(triggerTime1, data.Annotations{})
+	fc.buf.MarkShouldSend(triggerTime1)
 
 	// Should first capture images 3, 4, 5 (images in the before-trigger buffer)
 	expectedFirstTrigger := []time.Time{
@@ -752,7 +752,7 @@ func TestRingBufferTriggerWindows(t *testing.T) {
 
 	// Manually trigger at time 10, which should capture images 8, 9, 10
 	triggerTime2 := baseTime.Add(10 * time.Second)
-	fc.buf.MarkShouldSend(triggerTime2, data.Annotations{})
+	fc.buf.MarkShouldSend(triggerTime2)
 
 	// Should capture images 8, 9, 10
 	expectedTrigger := []time.Time{
@@ -1224,18 +1224,18 @@ func TestMultipleTriggerWindows(t *testing.T) {
 	}
 	// Manually trigger at time 5
 	triggerTime1 := baseTime.Add(5 * time.Second)
-	fc.buf.MarkShouldSend(triggerTime1, data.Annotations{})
+	fc.buf.MarkShouldSend(triggerTime1)
 	// Now add more images, with additional triggers at 7 and 9
 	fc.captureImageInBackground(ctx) // 6
 	fc.captureImageInBackground(ctx) // 7
 	// Manually trigger at time 7
 	triggerTime2 := baseTime.Add(7 * time.Second)
-	fc.buf.MarkShouldSend(triggerTime2, data.Annotations{})
+	fc.buf.MarkShouldSend(triggerTime2)
 	fc.captureImageInBackground(ctx) // 8
 	fc.captureImageInBackground(ctx) // 9
 	// Manually trigger at time 9
 	triggerTime3 := baseTime.Add(9 * time.Second)
-	fc.buf.MarkShouldSend(triggerTime3, data.Annotations{})
+	fc.buf.MarkShouldSend(triggerTime3)
 	for i := 10; i <= 20; i++ {
 		fc.captureImageInBackground(ctx)
 	}

--- a/conditional_camera/conditional_cam.go
+++ b/conditional_camera/conditional_cam.go
@@ -167,7 +167,7 @@ func (cc *conditionalCamera) images(ctx context.Context, extra map[string]interf
 			return nil, meta, err
 		}
 		if shouldSend {
-			cc.buf.MarkShouldSend(meta.CapturedAt, data.Annotations{})
+			cc.buf.MarkShouldSend(meta.CapturedAt)
 		}
 	}
 

--- a/image_buffer/image_buffer.go
+++ b/image_buffer/image_buffer.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"go.viam.com/rdk/components/camera"
-	"go.viam.com/rdk/data"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 )
@@ -32,7 +31,6 @@ type ImageBuffer struct {
 	maxImages           int
 	logger              logging.Logger
 	debug               bool
-	lastAnnotations     data.Annotations
 	// toSendMaxWarningThreshold is the threshold for warning about ToSend buffer size
 	toSendMaxWarningThreshold int
 }
@@ -62,11 +60,9 @@ func NewImageBuffer(windowSeconds int, imageFrequency float64, windowSecondsBefo
 	}
 }
 
-func (ib *ImageBuffer) MarkShouldSend(triggerTime time.Time, annotations data.Annotations) {
+func (ib *ImageBuffer) MarkShouldSend(triggerTime time.Time) {
 	ib.mu.Lock()
 	defer ib.mu.Unlock()
-
-	ib.lastAnnotations = annotations
 
 	// Add images from the ring buffer that are within the window
 	beforeTimeBoundary := time.Second * time.Duration(ib.windowSecondsBefore)
@@ -95,7 +91,6 @@ func (ib *ImageBuffer) MarkShouldSend(triggerTime time.Time, annotations data.An
 		if !cached.Meta.CapturedAt.Before(ib.captureFrom) && !cached.Meta.CapturedAt.After(ib.captureTill) {
 			// Check if this image is already in ToSend to avoid duplicates
 			if !existingTimes[cached.Meta.CapturedAt.UnixNano()] {
-				ib.updateAnnotations(&cached)
 				imagesToSend = append(imagesToSend, cached)
 			}
 			// if its a duplicate, then discard it
@@ -304,7 +299,6 @@ func (ib *ImageBuffer) StoreImages(images []camera.NamedImage, meta resource.Res
 	// else then store them in the ring buffer
 	if (now.Before(ib.captureTill) && now.After(ib.captureFrom)) || now.Equal(ib.captureTill) || now.Equal(ib.captureFrom) {
 		cd := CachedData{Imgs: images, Meta: meta}
-		ib.updateAnnotations(&cd)
 		ib.toSend = append(ib.toSend, cd)
 		toSendLen := len(ib.toSend)
 		if ib.debug {
@@ -332,14 +326,6 @@ func (ib *ImageBuffer) StoreImages(images []camera.NamedImage, meta resource.Res
 				"method", "StoreImages",
 				"withinCaptureWindow", false,
 				"ringBufferSize", len(ib.ringBuffer))
-		}
-	}
-}
-
-func (ib *ImageBuffer) updateAnnotations(cd *CachedData) {
-	for i, img := range cd.Imgs {
-		if len(img.Annotations.BoundingBoxes) == 0 && len(img.Annotations.Classifications) == 0 {
-			cd.Imgs[i].Annotations = ib.lastAnnotations
 		}
 	}
 }

--- a/image_buffer/image_buffer_test.go
+++ b/image_buffer/image_buffer_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"go.viam.com/rdk/data"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 
@@ -29,7 +28,7 @@ func TestWindow(t *testing.T) {
 		{Meta: resource.ResponseMetadata{CapturedAt: c}},
 	}
 
-	buf.MarkShouldSend(time.Now(), data.Annotations{})
+	buf.MarkShouldSend(time.Now())
 
 	// With the new implementation, we expect images within the window to be sent
 	test.That(t, buf.GetToSendLength(), test.ShouldEqual, 2)
@@ -45,7 +44,7 @@ func TestWindow(t *testing.T) {
 	}
 	buf.ClearToSend()
 
-	buf.MarkShouldSend(time.Now(), data.Annotations{})
+	buf.MarkShouldSend(time.Now())
 
 	// Test that the ring buffer now only contains images that were NOT sent (c was outside window)
 	test.That(t, buf.GetRingBufferLength(), test.ShouldEqual, 1)
@@ -68,7 +67,7 @@ func TestWindowBoundaries(t *testing.T) {
 		{Meta: resource.ResponseMetadata{CapturedAt: c}},
 	}
 
-	buf.MarkShouldSend(time.Now(), data.Annotations{})
+	buf.MarkShouldSend(time.Now())
 
 	// With the new implementation, we expect images within the window to be sent
 	test.That(t, buf.GetToSendLength(), test.ShouldEqual, 2)
@@ -84,7 +83,7 @@ func TestWindowBoundaries(t *testing.T) {
 	}
 	buf.ClearToSend()
 
-	buf.MarkShouldSend(time.Now(), data.Annotations{})
+	buf.MarkShouldSend(time.Now())
 
 	// Test that the ring buffer now only contains images that were NOT sent (c was outside window)
 	test.That(t, buf.GetRingBufferLength(), test.ShouldEqual, 1)


### PR DESCRIPTION
This is simply done by no longer caching the annotation and only uploading the annotation with the image that triggered the save.

Edited tests and updated the README with the behavior (and other features that were not documented)