### PR TITLE
add cooldown parameter to filtered-camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ On the new component panel, copy and paste the following attribute template into
     "window_seconds_before": <time_window_for_capture_before>,
     "window_seconds_after": <time_window_for_capture_after>,
     "image_frequency": <capture_rate_of_images_in_buffer>,
+    "cooldown_s": <optional_cooldown_seconds_after_capture_window>
 }
 ```
 
@@ -92,6 +93,7 @@ The following attributes are available for `viam:camera:filtered-camera` bases:
 | `window_seconds_before` | float64 | **Required** | The size of the time window (in seconds) before the condition is met, during which images are buffered. This allows you to see the photos taken in the specified number of seconds preceding the condition being met. |
 | `window_seconds_after` | float64 |  **Required** | The size of the time window (in seconds) after the condition is met, during which images are buffered. This allows you to see the photos taken in the specified number of seconds after the condition being met. |
 | `image_frequency` | float64 | Optional | the frequency at which to place images into the buffer (in Hz). Default value is 1.0 Hz |
+| `cooldown_s` | int | Optional | The number of seconds to suppress new triggers after a capture window ends. Useful when trigger events happen frequently but you don't need data every time. Default: 0 (no cooldown). |
 | `debug` | bool | Optional | Enable debug logging for detailed information about image buffering, filtering decisions, and capture windows. Default value is false |
 | `vision` | string | **Required** | \*\***DEPRECATED** use `vision_services` attribute instead \*\*. The vision service used for image classifications or detections. |
 | `classifications` | float64 | Optional | \*\***DEPRECATED** Use `vision_services`\*\* A map of classification labels and the confidence scores required for filtering. Use this if the ML model behind your vision service is a classifier. You can find these labels by testing your vision service. |
@@ -143,6 +145,7 @@ The filtered camera tracks statistics about accepted and rejected images. You ca
     ],
     "window_seconds": 6,
     "image_frequency": 0.5,
+    "cooldown_s": 30
 }
 ```
 
@@ -202,6 +205,7 @@ The following attributes are available for `viam:camera:conditional-camera` base
 | `window_seconds_after` | float64 | Optional | The size of the time window (in seconds) after the condition is met, during which images are buffered. This allows you to see the photos taken in the specified number of seconds after the condition being met. |
 | `window_seconds` | float64 | Optional | The size of the time window (in seconds) during which images are buffered. When a condition is met, a confidence score for a detection/classification exceeds the required confidence score, the buffered images are stored, allowing us to see the photos taken in the specified number of seconds preceding and after the condition being met. If this value is set, the 'window_seconds_before' and 'window_seconds_after' variable must both be set to 0.0. |
 | `image_frequency` | float64 | Optional | the frequency at which to place images into the buffer (in Hz). Default value is 1.0 Hz |
+| `cooldown_s` | int | Optional | The number of seconds to suppress new triggers after a capture window ends. Useful when trigger events happen frequently but you don't need data every time. Default: 0 (no cooldown). |
 | `debug` | bool | Optional | Enable debug logging for detailed information about image buffering, filtering decisions, and capture windows. Default value is false |
 
 On the new component panel, copy and paste the following attribute template into your camera’s **Attributes** box.
@@ -212,7 +216,8 @@ On the new component panel, copy and paste the following attribute template into
     "filter_service": "<your_vision_service_name>",
     "window_seconds": <time_window_for_capture>,
     "window_seconds_before": <time_window_for_capture_before>,
-    "window_seconds_after": <time_window_for_capture_after>
+    "window_seconds_after": <time_window_for_capture_after>,
+    "cooldown_s": <optional_cooldown_seconds_after_capture_window>
 }
 ```
 
@@ -227,6 +232,7 @@ On the new component panel, copy and paste the following attribute template into
     "filter_service": "is_too_hot",
     "window_seconds_before": 3,
     "window_seconds_after": 7,
+    "cooldown_s": 30
 }
 ```
 

--- a/cam.go
+++ b/cam.go
@@ -33,6 +33,7 @@ type Config struct {
 	ImageFrequency      float64               `json:"image_frequency"`
 	WindowSecondsBefore int                   `json:"window_seconds_before"`
 	WindowSecondsAfter  int                   `json:"window_seconds_after"`
+	CooldownSecs        int                   `json:"cooldown_s"`
 	Debug               bool                  `json:"debug"`
 
 	Classifications map[string]float64
@@ -81,6 +82,10 @@ func (cfg *Config) Validate(path string) ([]string, []string, error) {
 	} else if cfg.WindowSeconds > 0 && (cfg.WindowSecondsBefore > 0 || cfg.WindowSecondsAfter > 0) {
 		return nil, nil, utils.NewConfigValidationError(path,
 			errors.New("if window_seconds is set, window_seconds_before and window_seconds_after must not be"))
+	}
+
+	if cfg.CooldownSecs < 0 {
+		return nil, nil, utils.NewConfigValidationError(path, errors.New("cooldown_s cannot be negative"))
 	}
 
 	deps := []string{cfg.Camera}
@@ -179,7 +184,7 @@ func init() {
 			if imageFreq == 0 {
 				imageFreq = defaultImageFreq
 			}
-			fc.buf = imagebuffer.NewImageBuffer(newConf.WindowSeconds, imageFreq, newConf.WindowSecondsBefore, newConf.WindowSecondsAfter, logger, newConf.Debug)
+			fc.buf = imagebuffer.NewImageBuffer(newConf.WindowSeconds, imageFreq, newConf.WindowSecondsBefore, newConf.WindowSecondsAfter, logger, newConf.Debug, newConf.CooldownSecs)
 
 			// Initialize background image capture worker
 			fc.backgroundWorkers = utils.NewStoppableWorkerWithTicker(
@@ -406,6 +411,22 @@ func (fc *filteredCamera) images(ctx context.Context, filterSourceNames []string
 		return timestampedImages, meta, nil
 	}
 
+	// If we're in the cooldown period after a capture window, suppress new triggers
+	if fc.buf.IsInCooldown(meta.CapturedAt) {
+		if fc.conf.Debug {
+			fc.logger.Infow("Skipping trigger checks - in cooldown period",
+				"method", "images",
+				"singleImageMode", singleImageMode,
+				"capturedAt", meta.CapturedAt,
+				"inCooldown", true)
+		}
+		// Still return any remaining buffered images from the previous trigger
+		if bufferedImages, bufferedMeta, ok := fc.getBufferedImages(singleImageMode); ok {
+			return bufferedImages, bufferedMeta, nil
+		}
+		return nil, meta, data.ErrNoCaptureToStore
+	}
+
 	if fc.conf.Debug {
 		fc.logger.Infow("Running filter checks",
 			"method", "images",
@@ -548,7 +569,7 @@ func classificationToAnnotations(cs []classification.Classification) data.Annota
 
 func detectionsToAnnotations(ds []objectdetection.Detection) data.Annotations {
 	annotations := data.Annotations{
-		BoundingBoxes:   make([]data.BoundingBox, 0, len(ds)),
+		BoundingBoxes: make([]data.BoundingBox, 0, len(ds)),
 	}
 	for _, d := range ds {
 		score := d.Score()

--- a/cam_test.go
+++ b/cam_test.go
@@ -117,7 +117,7 @@ func TestShouldSend(t *testing.T) {
 		},
 		acceptedClassifications: map[string]map[string]float64{"": {"a": .8}},
 		acceptedObjects:         map[string]map[string]float64{"": {"b": .8}},
-		buf:                     imagebuffer.NewImageBuffer(10, 1.0, 0, 0, logging.NewTestLogger(t), true),
+		buf:                     imagebuffer.NewImageBuffer(10, 1.0, 0, 0, logging.NewTestLogger(t), true, 0),
 	}
 
 	res, _, err := fc.shouldSend(context.Background(), namedD, time.Now())
@@ -402,7 +402,7 @@ func TestImage(t *testing.T) {
 		otherVisionServices: []vision.Service{
 			getDummyVisionService(),
 		},
-		buf: imagebuffer.NewImageBuffer(10, 1.0, 0, 0, logging.NewTestLogger(t), true),
+		buf: imagebuffer.NewImageBuffer(10, 1.0, 0, 0, logging.NewTestLogger(t), true, 0),
 		cam: &inject.Camera{
 			ImagesFunc: func(ctx context.Context, filterSourceNames []string, extra map[string]interface{}) ([]camera.NamedImage, resource.ResponseMetadata, error) {
 				imgA, _ := camera.NamedImageFromImage(a, "", "image/jpeg", data.Annotations{})
@@ -446,7 +446,7 @@ func TestImages(t *testing.T) {
 		otherVisionServices: []vision.Service{
 			getDummyVisionService(),
 		},
-		buf: imagebuffer.NewImageBuffer(10, 1.0, 0, 0, logging.NewTestLogger(t), true),
+		buf: imagebuffer.NewImageBuffer(10, 1.0, 0, 0, logging.NewTestLogger(t), true, 0),
 		cam: &inject.Camera{
 			ImagesFunc: func(ctx context.Context, filterSourceNames []string, extra map[string]interface{}) ([]camera.NamedImage, resource.ResponseMetadata, error) {
 				return namedImages, resource.ResponseMetadata{CapturedAt: timestamp}, nil
@@ -480,7 +480,7 @@ func TestImageWithBufferedImages(t *testing.T) {
 		otherVisionServices: []vision.Service{
 			getDummyVisionService(),
 		},
-		buf: imagebuffer.NewImageBuffer(10, 1.0, 0, 0, logging.NewTestLogger(t), true),
+		buf: imagebuffer.NewImageBuffer(10, 1.0, 0, 0, logging.NewTestLogger(t), true, 0),
 		cam: &inject.Camera{
 			ImagesFunc: func(ctx context.Context, filterSourceNames []string, extra map[string]interface{}) ([]camera.NamedImage, resource.ResponseMetadata, error) {
 				img, _ := camera.NamedImageFromImage(a, "trigger_img", "image/jpeg", data.Annotations{})
@@ -528,7 +528,7 @@ func TestImagesWithBufferedImages(t *testing.T) {
 		otherVisionServices: []vision.Service{
 			getDummyVisionService(),
 		},
-		buf: imagebuffer.NewImageBuffer(10, 1.0, 0, 0, logging.NewTestLogger(t), true),
+		buf: imagebuffer.NewImageBuffer(10, 1.0, 0, 0, logging.NewTestLogger(t), true, 0),
 		cam: &inject.Camera{
 			ImagesFunc: func(ctx context.Context, filterSourceNames []string, extra map[string]interface{}) ([]camera.NamedImage, resource.ResponseMetadata, error) {
 				img, _ := camera.NamedImageFromImage(a, "trigger_img", "image/jpeg", data.Annotations{})
@@ -604,7 +604,7 @@ func TestProperties(t *testing.T) {
 		otherVisionServices: []vision.Service{
 			getDummyVisionService(),
 		},
-		buf: imagebuffer.NewImageBuffer(10, 1.0, 0, 0, logging.NewTestLogger(t), true),
+		buf: imagebuffer.NewImageBuffer(10, 1.0, 0, 0, logging.NewTestLogger(t), true, 0),
 		cam: &inject.Camera{
 			PropertiesFunc: func(ctx context.Context) (camera.Properties, error) {
 				return properties, nil
@@ -630,7 +630,7 @@ func TestDoCommand(t *testing.T) {
 		otherVisionServices: []vision.Service{
 			getDummyVisionService(),
 		},
-		buf: imagebuffer.NewImageBuffer(10, 1.0, 0, 0, logging.NewTestLogger(t), true),
+		buf: imagebuffer.NewImageBuffer(10, 1.0, 0, 0, logging.NewTestLogger(t), true, 0),
 		cam: &inject.Camera{
 			ImagesFunc: func(ctx context.Context, filterSourceNames []string, extra map[string]interface{}) ([]camera.NamedImage, resource.ResponseMetadata, error) {
 				imgA, _ := camera.NamedImageFromImage(a, "", "image/jpeg", data.Annotations{})
@@ -717,7 +717,7 @@ func TestRingBufferTriggerWindows(t *testing.T) {
 
 	// Use a base time that's close to current time to make windows work
 	// Initialize the image buffer
-	fc.buf = imagebuffer.NewImageBuffer(fc.conf.WindowSeconds, fc.conf.ImageFrequency, 0, 0, logging.NewTestLogger(t), true)
+	fc.buf = imagebuffer.NewImageBuffer(fc.conf.WindowSeconds, fc.conf.ImageFrequency, 0, 0, logging.NewTestLogger(t), true, 0)
 
 	// First, add images at times 1, 2, 3, 4, 5
 	for i := 1; i <= 5; i++ {
@@ -836,7 +836,7 @@ func TestBatchingWithFrequencyMismatch(t *testing.T) {
 	}
 
 	// Initialize image buffer: (3+2) * 1.0 = 5 images max in ring buffer
-	fc.buf = imagebuffer.NewImageBuffer(0, fc.conf.ImageFrequency, fc.conf.WindowSecondsBefore, fc.conf.WindowSecondsAfter, logging.NewTestLogger(t), true)
+	fc.buf = imagebuffer.NewImageBuffer(0, fc.conf.ImageFrequency, fc.conf.WindowSecondsBefore, fc.conf.WindowSecondsAfter, logging.NewTestLogger(t), true, 0)
 
 	// Ticks 1-4: Background captures
 	for i := 1; i <= 4; i++ {
@@ -995,7 +995,7 @@ func TestOverlappingTriggerWindows(t *testing.T) {
 	}
 
 	// Initialize image buffer: (10+2) * 1.0 = 12 images max in ring buffer
-	fc.buf = imagebuffer.NewImageBuffer(0, fc.conf.ImageFrequency, fc.conf.WindowSecondsBefore, fc.conf.WindowSecondsAfter, logging.NewTestLogger(t), true)
+	fc.buf = imagebuffer.NewImageBuffer(0, fc.conf.ImageFrequency, fc.conf.WindowSecondsBefore, fc.conf.WindowSecondsAfter, logging.NewTestLogger(t), true, 0)
 
 	// Build up ring buffer with 15 images
 	for i := 1; i <= 15; i++ {
@@ -1138,7 +1138,7 @@ func TestCurrentImageTimestampingInCaptureWindow(t *testing.T) {
 	}
 
 	// Initialize image buffer
-	fc.buf = imagebuffer.NewImageBuffer(0, fc.conf.ImageFrequency, fc.conf.WindowSecondsBefore, fc.conf.WindowSecondsAfter, logging.NewTestLogger(t), true)
+	fc.buf = imagebuffer.NewImageBuffer(0, fc.conf.ImageFrequency, fc.conf.WindowSecondsBefore, fc.conf.WindowSecondsAfter, logging.NewTestLogger(t), true, 0)
 
 	// Step 1: Build up some ring buffer by capturing background images (simulate background worker)
 	for i := 0; i < 5; i++ {
@@ -1222,7 +1222,7 @@ func TestMultipleTriggerWindows(t *testing.T) {
 
 	// Use a base time that's close to current time to make windows work
 	// Initialize the image buffer
-	fc.buf = imagebuffer.NewImageBuffer(fc.conf.WindowSeconds, fc.conf.ImageFrequency, 0, 0, logging.NewTestLogger(t), true)
+	fc.buf = imagebuffer.NewImageBuffer(fc.conf.WindowSeconds, fc.conf.ImageFrequency, 0, 0, logging.NewTestLogger(t), true, 0)
 
 	// First, add images at times 1, 2, 3, 4, 5
 	for i := 1; i <= 5; i++ {
@@ -1312,7 +1312,7 @@ func TestNoDuplicateImagesAcrossGetImagesCalls(t *testing.T) {
 	}
 
 	// Initialize image buffer
-	fc.buf = imagebuffer.NewImageBuffer(0, fc.conf.ImageFrequency, fc.conf.WindowSecondsBefore, fc.conf.WindowSecondsAfter, logging.NewTestLogger(t), true)
+	fc.buf = imagebuffer.NewImageBuffer(0, fc.conf.ImageFrequency, fc.conf.WindowSecondsBefore, fc.conf.WindowSecondsAfter, logging.NewTestLogger(t), true, 0)
 
 	// Add data management context
 
@@ -1364,4 +1364,173 @@ func TestNoDuplicateImagesAcrossGetImagesCalls(t *testing.T) {
 		}
 	}
 	test.That(t, duplicateFound, test.ShouldBeFalse)
+}
+
+func TestCooldownValidation(t *testing.T) {
+	conf := &Config{
+		Camera:         "my_camera",
+		Vision:         "my_vision",
+		WindowSeconds:  10,
+		ImageFrequency: 1.0,
+	}
+
+	// cooldown_s = 0 (default) should be valid
+	conf.CooldownSecs = 0
+	res, _, err := conf.Validate(".")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, res, test.ShouldNotBeNil)
+
+	// cooldown_s = 30 should be valid
+	conf.CooldownSecs = 30
+	res, _, err = conf.Validate(".")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, res, test.ShouldNotBeNil)
+
+	// cooldown_s = -1 should fail validation
+	conf.CooldownSecs = -1
+	res, _, err = conf.Validate(".")
+	test.That(t, res, test.ShouldBeNil)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "cooldown_s cannot be negative")
+}
+
+func TestCooldownSuppressesNewTrigger(t *testing.T) {
+	// Tests that during cooldown period, new triggers are suppressed and ErrNoCaptureToStore is returned
+	logger := logging.NewTestLogger(t)
+	ctx := context.Background()
+	baseTime := time.Now()
+
+	captureCount := 0
+	imagesCam := inject.NewCamera("test_camera")
+	imagesCam.ImagesFunc = func(ctx context.Context, filterSourceNames []string, extra map[string]interface{}) (
+		[]camera.NamedImage, resource.ResponseMetadata, error) {
+		captureCount++
+		imageTime := baseTime.Add(time.Duration(captureCount) * time.Second)
+		img, _ := camera.NamedImageFromImage(image.NewRGBA(image.Rect(0, 0, 10, 10)), fmt.Sprintf("img_%d", captureCount), "image/jpeg", data.Annotations{})
+		return []camera.NamedImage{img}, resource.ResponseMetadata{CapturedAt: imageTime}, nil
+	}
+
+	// Vision service always triggers
+	visionSvc := inject.NewVisionService("test_vision")
+	visionSvc.ClassificationsFunc = func(ctx context.Context, img image.Image, n int, extra map[string]interface{}) (classification.Classifications, error) {
+		return classification.Classifications{
+			classification.NewClassification(0.9, "person"),
+		}, nil
+	}
+
+	fc := &filteredCamera{
+		conf: &Config{
+			Classifications:     map[string]float64{"person": 0.8},
+			WindowSecondsBefore: 2,
+			WindowSecondsAfter:  2,
+			CooldownSecs:        10,
+			ImageFrequency:      1.0,
+			Debug:               true,
+		},
+		logger:                   logger,
+		cam:                      imagesCam,
+		otherVisionServices:      []vision.Service{visionSvc},
+		acceptedClassifications:  map[string]map[string]float64{"test_vision": {"person": 0.8}},
+		acceptedObjects:          map[string]map[string]float64{},
+		inhibitedClassifications: map[string]map[string]float64{},
+		inhibitedObjects:         map[string]map[string]float64{},
+		inhibitors:               []vision.Service{},
+	}
+
+	fc.buf = imagebuffer.NewImageBuffer(0, fc.conf.ImageFrequency, fc.conf.WindowSecondsBefore, fc.conf.WindowSecondsAfter, logger, true, fc.conf.CooldownSecs)
+
+	// Build up ring buffer
+	for i := 0; i < 5; i++ {
+		fc.captureImageInBackground(ctx)
+	}
+
+	// First trigger should succeed
+	images1, _, err1 := fc.Images(ctx, nil, map[string]interface{}{data.FromDMString: true})
+	test.That(t, err1, test.ShouldBeNil)
+	test.That(t, len(images1), test.ShouldBeGreaterThan, 0)
+
+	// Drain any remaining buffered images
+	fc.buf.ClearToSend()
+
+	// Set captureTill to the past to simulate capture window ending
+	// and cooldownTill to the future to simulate being in cooldown
+	pastCaptureTill := time.Now().Add(-1 * time.Second)
+	fc.buf.SetCaptureTill(pastCaptureTill)
+	fc.buf.SetCooldownTill(time.Now().Add(10 * time.Second))
+
+	// Next call should be suppressed by cooldown - despite vision service returning positive
+	images2, _, err2 := fc.Images(ctx, nil, map[string]interface{}{data.FromDMString: true})
+	test.That(t, err2, test.ShouldEqual, data.ErrNoCaptureToStore)
+	test.That(t, images2, test.ShouldBeNil)
+}
+
+func TestCooldownAllowsTriggerAfterExpiry(t *testing.T) {
+	// Tests that after cooldown expires, triggers work again
+	logger := logging.NewTestLogger(t)
+	ctx := context.Background()
+	baseTime := time.Now()
+
+	captureCount := 0
+	imagesCam := inject.NewCamera("test_camera")
+	imagesCam.ImagesFunc = func(ctx context.Context, filterSourceNames []string, extra map[string]interface{}) (
+		[]camera.NamedImage, resource.ResponseMetadata, error) {
+		captureCount++
+		imageTime := baseTime.Add(time.Duration(captureCount) * time.Second)
+		img, _ := camera.NamedImageFromImage(image.NewRGBA(image.Rect(0, 0, 10, 10)), fmt.Sprintf("img_%d", captureCount), "image/jpeg", data.Annotations{})
+		return []camera.NamedImage{img}, resource.ResponseMetadata{CapturedAt: imageTime}, nil
+	}
+
+	// Vision service always triggers
+	visionSvc := inject.NewVisionService("test_vision")
+	visionSvc.ClassificationsFunc = func(ctx context.Context, img image.Image, n int, extra map[string]interface{}) (classification.Classifications, error) {
+		return classification.Classifications{
+			classification.NewClassification(0.9, "person"),
+		}, nil
+	}
+
+	fc := &filteredCamera{
+		conf: &Config{
+			Classifications:     map[string]float64{"person": 0.8},
+			WindowSecondsBefore: 2,
+			WindowSecondsAfter:  2,
+			CooldownSecs:        5,
+			ImageFrequency:      1.0,
+			Debug:               true,
+		},
+		logger:                   logger,
+		cam:                      imagesCam,
+		otherVisionServices:      []vision.Service{visionSvc},
+		acceptedClassifications:  map[string]map[string]float64{"test_vision": {"person": 0.8}},
+		acceptedObjects:          map[string]map[string]float64{},
+		inhibitedClassifications: map[string]map[string]float64{},
+		inhibitedObjects:         map[string]map[string]float64{},
+		inhibitors:               []vision.Service{},
+	}
+
+	fc.buf = imagebuffer.NewImageBuffer(0, fc.conf.ImageFrequency, fc.conf.WindowSecondsBefore, fc.conf.WindowSecondsAfter, logger, true, fc.conf.CooldownSecs)
+
+	// Build up ring buffer
+	for i := 0; i < 5; i++ {
+		fc.captureImageInBackground(ctx)
+	}
+
+	// First trigger should succeed
+	images1, _, err1 := fc.Images(ctx, nil, map[string]interface{}{data.FromDMString: true})
+	test.That(t, err1, test.ShouldBeNil)
+	test.That(t, len(images1), test.ShouldBeGreaterThan, 0)
+
+	// Clear buffers and set captureTill and cooldownTill to the past to simulate expired cooldown
+	fc.buf.ClearToSend()
+	fc.buf.SetCaptureTill(time.Now().Add(-10 * time.Second))
+	fc.buf.SetCooldownTill(time.Now().Add(-5 * time.Second))
+
+	// Build up ring buffer again
+	for i := 0; i < 5; i++ {
+		fc.captureImageInBackground(ctx)
+	}
+
+	// Should be able to trigger again after cooldown expired
+	images2, _, err2 := fc.Images(ctx, nil, map[string]interface{}{data.FromDMString: true})
+	test.That(t, err2, test.ShouldBeNil)
+	test.That(t, len(images2), test.ShouldBeGreaterThan, 0)
 }

--- a/conditional_camera/conditional_cam.go
+++ b/conditional_camera/conditional_cam.go
@@ -33,6 +33,7 @@ type Config struct {
 	ImageFrequency      float64 `json:"image_frequency"`
 	WindowSecondsBefore int     `json:"window_seconds_before"`
 	WindowSecondsAfter  int     `json:"window_seconds_after"`
+	CooldownSecs        int     `json:"cooldown_s"`
 	Debug               bool    `json:"debug"`
 }
 
@@ -55,6 +56,10 @@ func (cfg *Config) Validate(path string) ([]string, []string, error) {
 	} else if cfg.WindowSeconds > 0 && (cfg.WindowSecondsBefore > 0 || cfg.WindowSecondsAfter > 0) {
 		return nil, nil, utils.NewConfigValidationError(path,
 			errors.New("if window_seconds is set, window_seconds_before and window_seconds_after must not be"))
+	}
+
+	if cfg.CooldownSecs < 0 {
+		return nil, nil, utils.NewConfigValidationError(path, errors.New("cooldown_s cannot be negative"))
 	}
 
 	return []string{cfg.Camera, cfg.FilterSvc}, nil, nil
@@ -85,7 +90,7 @@ func init() {
 			if imageFreq == 0 {
 				imageFreq = 1.0
 			}
-			cc.buf = imagebuffer.NewImageBuffer(newConf.WindowSeconds, imageFreq, newConf.WindowSecondsBefore, newConf.WindowSecondsAfter, logger, newConf.Debug)
+			cc.buf = imagebuffer.NewImageBuffer(newConf.WindowSeconds, imageFreq, newConf.WindowSecondsBefore, newConf.WindowSecondsAfter, logger, newConf.Debug, newConf.CooldownSecs)
 
 			return cc, nil
 		},
@@ -156,6 +161,15 @@ func (cc *conditionalCamera) images(ctx context.Context, extra map[string]interf
 		}
 		// If no buffered images, return current image (we're in capture mode)
 		return images, meta, nil
+	}
+
+	// If we're in the cooldown period after a capture window, suppress new triggers
+	if cc.buf.IsInCooldown(meta.CapturedAt) {
+		// Still return any remaining buffered images from the previous trigger
+		if bufferedImages, bufferedMeta, ok := cc.getBufferedImages(singleImageMode); ok {
+			return bufferedImages, bufferedMeta, nil
+		}
+		return nil, meta, data.ErrNoCaptureToStore
 	}
 
 	// We're outside capture window, add to ring buffer and run filter checks

--- a/image_buffer/image_buffer.go
+++ b/image_buffer/image_buffer.go
@@ -25,6 +25,8 @@ type ImageBuffer struct {
 	toSend              []CachedData
 	captureFrom         time.Time
 	captureTill         time.Time
+	cooldownTill        time.Time
+	cooldownSecs        int
 	windowSecondsBefore int
 	windowSecondsAfter  int
 	imageFrequency      float64
@@ -35,7 +37,7 @@ type ImageBuffer struct {
 	toSendMaxWarningThreshold int
 }
 
-func NewImageBuffer(windowSeconds int, imageFrequency float64, windowSecondsBefore int, windowSecondsAfter int, logger logging.Logger, debug bool) *ImageBuffer {
+func NewImageBuffer(windowSeconds int, imageFrequency float64, windowSecondsBefore int, windowSecondsAfter int, logger logging.Logger, debug bool, cooldownSecs int) *ImageBuffer {
 	// Calculate the maximum number of images to keep in the ring buffer
 	// Keep images for 2 * windowSeconds (before and after trigger)
 	var maxImages int
@@ -51,6 +53,7 @@ func NewImageBuffer(windowSeconds int, imageFrequency float64, windowSecondsBefo
 		toSend:              []CachedData{},
 		windowSecondsBefore: windowSecondsBefore,
 		windowSecondsAfter:  windowSecondsAfter,
+		cooldownSecs:        cooldownSecs,
 		imageFrequency:      imageFrequency,
 		maxImages:           maxImages,
 		logger:              logger,
@@ -75,6 +78,7 @@ func (ib *ImageBuffer) MarkShouldSend(triggerTime time.Time) {
 		ib.captureFrom = newCaptureFrom
 	}
 	ib.captureTill = newCaptureTill
+	ib.cooldownTill = newCaptureTill.Add(time.Duration(ib.cooldownSecs) * time.Second)
 
 	// Send images from the ring buffer and continue collecting for windowDuration
 	var imagesToSend []CachedData
@@ -113,6 +117,7 @@ func (ib *ImageBuffer) MarkShouldSend(triggerTime time.Time) {
 			"triggerTime", triggerTime.Format(timestampFormat),
 			"captureFrom", ib.captureFrom.Format(timestampFormat),
 			"captureTill", ib.captureTill.Format(timestampFormat),
+			"cooldownTill", ib.cooldownTill.Format(timestampFormat),
 			"imagesAdded", len(imagesToSend),
 			"toSendSize", toSendLen,
 			"ringBufferSize", len(ib.ringBuffer))
@@ -143,6 +148,14 @@ func (ib *ImageBuffer) SetCaptureTill(t time.Time) {
 	ib.mu.Lock()
 	defer ib.mu.Unlock()
 	ib.captureTill = t
+}
+
+// SetCooldownTill sets the cooldownTill time
+// This method is only used for testing purposes
+func (ib *ImageBuffer) SetCooldownTill(t time.Time) {
+	ib.mu.Lock()
+	defer ib.mu.Unlock()
+	ib.cooldownTill = t
 }
 
 // GetToSendLength returns the length of the toSend slice
@@ -269,6 +282,28 @@ func (ib *ImageBuffer) GetToSendSlice() []CachedData {
 	ib.mu.Lock()
 	defer ib.mu.Unlock()
 	return append([]CachedData{}, ib.toSend...)
+}
+
+// IsInCooldown returns true if the given time is after the capture window has ended
+// but before the cooldown period has expired. During cooldown, new triggers should be suppressed.
+func (ib *ImageBuffer) IsInCooldown(now time.Time) bool {
+	ib.mu.Lock()
+	defer ib.mu.Unlock()
+
+	afterCaptureWindow := now.After(ib.captureTill)
+	beforeCooldownEnd := now.Before(ib.cooldownTill) || now.Equal(ib.cooldownTill)
+	inCooldown := afterCaptureWindow && beforeCooldownEnd
+
+	if ib.debug {
+		ib.logger.Infow("IsInCooldown check",
+			"method", "IsInCooldown",
+			"now", now.Format(timestampFormat),
+			"captureTill", ib.captureTill.Format(timestampFormat),
+			"cooldownTill", ib.cooldownTill.Format(timestampFormat),
+			"inCooldown", inCooldown)
+	}
+
+	return inCooldown
 }
 
 // IsWithinCaptureWindow returns true if the given time is within the current capture window

--- a/image_buffer/image_buffer_test.go
+++ b/image_buffer/image_buffer_test.go
@@ -20,7 +20,7 @@ func TestWindow(t *testing.T) {
 
 	// Initialize the image buffer
 	logger := logging.NewTestLogger(t)
-	buf := NewImageBuffer(10, 1.0, 0, 0, logger, true) // Enable debug for tests
+	buf := NewImageBuffer(10, 1.0, 0, 0, logger, true, 0) // Enable debug for tests
 
 	buf.ringBuffer = []CachedData{
 		{Meta: resource.ResponseMetadata{CapturedAt: a}},
@@ -59,7 +59,7 @@ func TestWindowBoundaries(t *testing.T) {
 
 	// Initialize the image buffer
 	logger := logging.NewTestLogger(t)
-	buf := NewImageBuffer(0, 1.0, 5, 10, logger, true) // Enable debug for tests
+	buf := NewImageBuffer(0, 1.0, 5, 10, logger, true, 0) // Enable debug for tests
 
 	buf.ringBuffer = []CachedData{
 		{Meta: resource.ResponseMetadata{CapturedAt: a}},
@@ -92,4 +92,70 @@ func TestWindowBoundaries(t *testing.T) {
 	test.That(t, b, test.ShouldEqual, toSendSlice[0].Meta.CapturedAt)
 	test.That(t, a, test.ShouldEqual, toSendSlice[1].Meta.CapturedAt)
 
+}
+
+func TestCooldownBlocksRetrigger(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	// cooldown=5s, window=2s (before and after)
+	buf := NewImageBuffer(2, 1.0, 0, 0, logger, true, 5)
+
+	triggerTime := time.Now()
+	buf.MarkShouldSend(triggerTime)
+
+	// captureTill = triggerTime + 2s, cooldownTill = captureTill + 5s = triggerTime + 7s
+	captureTill := triggerTime.Add(2 * time.Second)
+	cooldownTill := triggerTime.Add(7 * time.Second)
+
+	// Within capture window - not in cooldown
+	test.That(t, buf.IsInCooldown(triggerTime.Add(1*time.Second)), test.ShouldBeFalse)
+
+	// Just after capture window ends - should be in cooldown
+	test.That(t, buf.IsInCooldown(captureTill.Add(1*time.Second)), test.ShouldBeTrue)
+
+	// Still in cooldown near the end
+	test.That(t, buf.IsInCooldown(captureTill.Add(4*time.Second)), test.ShouldBeTrue)
+
+	// At cooldownTill boundary - still in cooldown (inclusive)
+	test.That(t, buf.IsInCooldown(cooldownTill), test.ShouldBeTrue)
+
+	// Past cooldownTill - no longer in cooldown
+	test.That(t, buf.IsInCooldown(cooldownTill.Add(1*time.Second)), test.ShouldBeFalse)
+}
+
+func TestCooldownZeroHasNoEffect(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	// cooldown=0 means no cooldown
+	buf := NewImageBuffer(2, 1.0, 0, 0, logger, true, 0)
+
+	triggerTime := time.Now()
+	buf.MarkShouldSend(triggerTime)
+
+	// captureTill = triggerTime + 2s, cooldownTill = captureTill + 0s = captureTill
+	captureTill := triggerTime.Add(2 * time.Second)
+
+	// Just after capture window - should NOT be in cooldown when cooldown=0
+	test.That(t, buf.IsInCooldown(captureTill.Add(1*time.Millisecond)), test.ShouldBeFalse)
+	test.That(t, buf.IsInCooldown(captureTill.Add(1*time.Second)), test.ShouldBeFalse)
+}
+
+func TestCooldownExtendsWithRetrigger(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	// cooldown=5s, window before=2s, after=2s
+	buf := NewImageBuffer(2, 1.0, 0, 0, logger, true, 5)
+
+	trigger1 := time.Now()
+	buf.MarkShouldSend(trigger1)
+	// captureTill = trigger1 + 2s, cooldownTill = trigger1 + 7s
+
+	// Second trigger within the capture window extends it
+	trigger2 := trigger1.Add(1 * time.Second) // within first capture window
+	buf.MarkShouldSend(trigger2)
+	// captureTill = trigger2 + 2s = trigger1 + 3s, cooldownTill = trigger1 + 3s + 5s = trigger1 + 8s
+
+	newCooldownTill := trigger1.Add(8 * time.Second)
+
+	// Should be in cooldown up to the extended cooldownTill
+	test.That(t, buf.IsInCooldown(trigger1.Add(4*time.Second)), test.ShouldBeTrue) // past captureTill (3s), before cooldownTill (8s)
+	test.That(t, buf.IsInCooldown(newCooldownTill), test.ShouldBeTrue)             // at boundary
+	test.That(t, buf.IsInCooldown(newCooldownTill.Add(1*time.Second)), test.ShouldBeFalse)
 }


### PR DESCRIPTION
  Core logic — image_buffer/image_buffer.go:
  - Added cooldownSecs and cooldownTill fields to ImageBuffer struct
  - Updated NewImageBuffer constructor with cooldownSecs parameter
  - MarkShouldSend now computes cooldownTill = captureTill + cooldownSecs
  - New IsInCooldown(now) method — returns true when past capture window but within cooldown period
  - New SetCooldownTill test helper
  - When cooldownSecs == 0, IsInCooldown naturally returns false (no cooldown)

  Filtered camera — cam.go:
  - Added CooldownSecs int with json:"cooldown_s" to Config
  - Validation: cooldown_s cannot be negative
  - Passed to NewImageBuffer in constructor
  - Added cooldown check in images() between IsWithinCaptureWindow and filter checks — during cooldown, drains remaining buffered images but suppresses new triggers

  Conditional camera — conditional_camera/conditional_cam.go:
  - Same config, validation, constructor, and images() cooldown check

  Tests:
  - 3 new unit tests in image_buffer_test.go: TestCooldownBlocksRetrigger, TestCooldownZeroHasNoEffect, TestCooldownExtendsWithRetrigger
  - 3 new integration tests in cam_test.go: TestCooldownValidation, TestCooldownSuppressesNewTrigger, TestCooldownAllowsTriggerAfterExpiry
  - All existing NewImageBuffer calls updated with 0 for backward compatibility