### PR TITLE
feat: allow vs to be source of image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ filtered-camera
 foo.json
 module.tar.gz
 .canon.yaml
+.VIAM_RELOAD_ARCHIVE.tar.gz

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ On the new component panel, copy and paste the following attribute template into
 Remove the "classifications" or "objects" section depending on if your ML model is a classifier or detector.
 
 > [!NOTE]
+> Instead of `camera`, you can set `image_vision_service` to the name of a vision service to use as the image source, useful when that vision service manipulates the underlying camera image (for example, cropping, blurring, or annotating it). `camera` and `image_vision_service` are mutually exclusive.
+
+> [!NOTE]
 > The filtered camera can be configured with both `ReadImage` and `Images` methods for data management. The camera detects data management calls through context and extra parameters to apply filtering only when appropriate.
 
 > [!NOTE]
@@ -88,7 +91,8 @@ The following attributes are available for `viam:camera:filtered-camera` bases:
 
 | Name | Type | Inclusion | Description |
 | ---- | ------ | ------------ | ----------- |
-| `camera` | string | **Required** | The name of the camera to filter images for. |
+| `camera` | string | **Required*** | The name of the camera to grab images from. Exactly one of `camera` or `image_vision_service` must be set. |
+| `image_vision_service` | string | **Required*** | The name of a vision service to grab images from instead of a camera. Use this if your vision service manipulates the underlying camera image (for example, cropping, blurring, or annotating it) and you want to filter and buffer that manipulated image rather than the raw camera image. The vision service is called via its `CaptureAllFromCamera` method with `ReturnImage` set to true, so it must have its own camera configured to pull from. Exactly one of `camera` or `image_vision_service` must be set. |
 | `vision_services` | list | **Required** | A list of 1 or more vision services used for image classifications or detections. |
 | `window_seconds_before` | float64 | Optional | The size of the time window (in seconds) before the condition is met, during which images are buffered. This allows you to see the photos taken in the specified number of seconds preceding the condition being met. If all window attributes are 0 (or omitted), no surrounding images are buffered and only the image that triggered the condition is captured. |
 | `window_seconds_after` | float64 | Optional | The size of the time window (in seconds) after the condition is met, during which images are buffered. This allows you to see the photos taken in the specified number of seconds after the condition being met. If all window attributes are 0 (or omitted), no surrounding images are buffered and only the image that triggered the condition is captured. |

--- a/cam.go
+++ b/cam.go
@@ -17,6 +17,7 @@ import (
 	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/rdk/vision/classification"
 	"go.viam.com/rdk/vision/objectdetection"
+	"go.viam.com/rdk/vision/viscapture"
 	"go.viam.com/utils"
 
 	imagebuffer "github.com/viam-modules/filtered_camera/image_buffer"
@@ -27,7 +28,14 @@ var Model = Family.WithModel("filtered-camera")
 const defaultImageFreq = 1.0
 
 type Config struct {
-	Camera string
+	// Camera is the name of the camera to grab images from. Exactly one of Camera or
+	// ImageVisionService must be set.
+	Camera string `json:"camera,omitempty"`
+	// ImageVisionService is the name of a vision service to grab images from instead of a camera.
+	// This is useful when the vision service manipulates the underlying camera image (e.g. crops,
+	// blurs, or annotates it) and that manipulated image is what should be filtered and buffered.
+	// Exactly one of Camera or ImageVisionService must be set.
+	ImageVisionService string `json:"image_vision_service,omitempty"`
 	// Deprecated: use VisionServices instead
 	Vision              string
 	VisionServices      []VisionServiceConfig `json:"vision_services,omitempty"`
@@ -59,8 +67,10 @@ func (config *VisionServiceConfig) Validate(path string) error {
 }
 
 func (cfg *Config) Validate(path string) ([]string, []string, error) {
-	if cfg.Camera == "" {
-		return nil, nil, utils.NewConfigValidationFieldRequiredError(path, "camera")
+	if cfg.Camera == "" && cfg.ImageVisionService == "" {
+		return nil, nil, utils.NewConfigValidationError(path, errors.New("must specify one of \"camera\" or \"image_vision_service\""))
+	} else if cfg.Camera != "" && cfg.ImageVisionService != "" {
+		return nil, nil, utils.NewConfigValidationError(path, errors.New("cannot specify both \"camera\" and \"image_vision_service\""))
 	}
 
 	if cfg.Vision == "" && cfg.VisionServices == nil {
@@ -87,7 +97,12 @@ func (cfg *Config) Validate(path string) ([]string, []string, error) {
 		return nil, nil, utils.NewConfigValidationError(path, errors.New("cooldown_s cannot be negative"))
 	}
 
-	deps := []string{cfg.Camera}
+	deps := []string{}
+	if cfg.Camera != "" {
+		deps = append(deps, cfg.Camera)
+	} else {
+		deps = append(deps, cfg.ImageVisionService)
+	}
 	inhibitors := []string{}
 	otherVisionServices := []string{}
 
@@ -124,13 +139,21 @@ func init() {
 
 			fc := &filteredCamera{Named: conf.ResourceName().AsNamed(), conf: newConf, logger: logger}
 
-			fc.cam, err = camera.FromDependencies(deps, newConf.Camera)
-			if err != nil {
-				return nil, err
+			if newConf.Camera != "" {
+				fc.cam, err = camera.FromProvider(deps, newConf.Camera)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				fc.imageVisionService, err = vision.FromProvider(deps, newConf.ImageVisionService)
+				if err != nil {
+					return nil, err
+				}
 			}
+
 			if newConf.Vision != "" {
 				fc.otherVisionServices = make([]vision.Service, 1)
-				fc.otherVisionServices[0], err = vision.FromDependencies(deps, newConf.Vision)
+				fc.otherVisionServices[0], err = vision.FromProvider(deps, newConf.Vision)
 				if err != nil {
 					return nil, err
 				}
@@ -151,7 +174,7 @@ func init() {
 				fc.inhibitedObjects = make(map[string]map[string]float64)
 				fc.acceptedObjects = make(map[string]map[string]float64)
 				for _, vs := range newConf.VisionServices {
-					visionService, err := vision.FromDependencies(deps, vs.Vision)
+					visionService, err := vision.FromProvider(deps, vs.Vision)
 					if err != nil {
 						return nil, err
 					}
@@ -208,6 +231,7 @@ type filteredCamera struct {
 	logger logging.Logger
 
 	cam                      camera.Camera
+	imageVisionService       vision.Service
 	buf                      *imagebuffer.ImageBuffer
 	backgroundWorkers        *utils.StoppableWorkers
 	inhibitors               []vision.Service
@@ -333,13 +357,42 @@ func (fc *filteredCamera) Close(ctx context.Context) error {
 }
 
 func (fc *filteredCamera) captureImageInBackground(ctx context.Context) {
-	images, meta, err := fc.cam.Images(ctx, nil, nil)
+	images, meta, err := fc.getSourceImages(ctx, nil, nil)
 	if err != nil {
 		fc.logger.Debugf("Error capturing image in background: %v", err)
 		return
 	}
 	now := meta.CapturedAt
 	fc.buf.StoreImages(images, meta, now)
+}
+
+// getSourceImages returns the base images to be filtered and buffered, pulling them either from
+// the configured camera or from the configured vision service.
+func (fc *filteredCamera) getSourceImages(
+	ctx context.Context, filterSourceNames []string, extra map[string]interface{},
+) ([]camera.NamedImage, resource.ResponseMetadata, error) {
+	if fc.cam != nil {
+		return fc.cam.Images(ctx, filterSourceNames, extra)
+	}
+	return fc.imagesFromVisionService(ctx, extra)
+}
+
+// imagesFromVisionService pulls the image from the vision service's CaptureAllFromCamera method,
+// which allows vision services that manipulate the underlying camera image (e.g. crops, blurs, or
+// annotates it) to be used as the image source instead of a camera.
+func (fc *filteredCamera) imagesFromVisionService(
+	ctx context.Context, extra map[string]interface{},
+) ([]camera.NamedImage, resource.ResponseMetadata, error) {
+	capture, err := fc.imageVisionService.CaptureAllFromCamera(ctx, "", viscapture.CaptureOptions{ReturnImage: true}, extra)
+	if err != nil {
+		return nil, resource.ResponseMetadata{}, err
+	}
+	if capture.Image == nil {
+		return nil, resource.ResponseMetadata{}, fmt.Errorf(
+			"vision service %q did not return an image", fc.imageVisionService.Name().Name)
+	}
+	meta := resource.ResponseMetadata{CapturedAt: time.Now()}
+	return []camera.NamedImage{*capture.Image}, meta, nil
 }
 
 func (fc *filteredCamera) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
@@ -373,8 +426,8 @@ func (fc *filteredCamera) getBufferedImages(singleImageMode bool) ([]camera.Name
 func (fc *filteredCamera) images(ctx context.Context, filterSourceNames []string, extra map[string]interface{}, singleImageMode bool) ([]camera.NamedImage, resource.ResponseMetadata, error) {
 	ctx, span := trace.StartSpan(ctx, "filteredcamera::images")
 	defer span.End()
-	// Always call underlying camera to get fresh images
-	images, meta, err := fc.cam.Images(ctx, filterSourceNames, extra)
+	// Always call the underlying image source to get fresh images
+	images, meta, err := fc.getSourceImages(ctx, filterSourceNames, extra)
 	if err != nil {
 		return images, meta, err
 	}
@@ -617,6 +670,11 @@ func (fc *filteredCamera) Geometries(ctx context.Context, extra map[string]inter
 }
 
 func (fc *filteredCamera) Properties(ctx context.Context) (camera.Properties, error) {
+	if fc.cam == nil {
+		// Images are sourced from a vision service rather than a camera dependency, so there's no
+		// underlying camera to ask for properties.
+		return camera.Properties{SupportsPCD: false}, nil
+	}
 	p, err := fc.cam.Properties(ctx)
 	if err == nil {
 		p.SupportsPCD = false

--- a/cam_test.go
+++ b/cam_test.go
@@ -17,6 +17,7 @@ import (
 	"go.viam.com/rdk/utils"
 	"go.viam.com/rdk/vision/classification"
 	"go.viam.com/rdk/vision/objectdetection"
+	"go.viam.com/rdk/vision/viscapture"
 
 	imagebuffer "github.com/viam-modules/filtered_camera/image_buffer"
 
@@ -278,12 +279,35 @@ func TestValidate(t *testing.T) {
 	res, _, err := conf.Validate(".")
 	test.That(t, res, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "\"camera\" is required")
+	test.That(t, err.Error(), test.ShouldContainSubstring, "must specify one of \"camera\" or \"image_vision_service\"")
 	conf.Camera = "foo"
 	res, _, err = conf.Validate(".")
 	test.That(t, res, test.ShouldBeNil)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "\"vision_services\" is required")
+
+	// should error if both camera and image_vision_service are set
+	conf.ImageVisionService = "image_source_vision"
+	res, _, err = conf.Validate(".")
+	test.That(t, res, test.ShouldBeNil)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "cannot specify both \"camera\" and \"image_vision_service\"")
+	conf.Camera = ""
+
+	// image_vision_service alone can satisfy the image source requirement
+	conf.VisionServices = []VisionServiceConfig{
+		{
+			Vision:          "foo",
+			Classifications: map[string]float64{"a": .8},
+		},
+	}
+	res, _, err = conf.Validate(".")
+	test.That(t, res, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, res, test.ShouldResemble, []string{"image_source_vision", "foo"})
+	conf.ImageVisionService = ""
+	conf.VisionServices = nil
+	conf.Camera = "foo"
 
 	conf.Vision = "foo"
 	res, _, err = conf.Validate(".")
@@ -434,6 +458,50 @@ func TestImages(t *testing.T) {
 	test.That(t, res, test.ShouldNotBeNil)
 	test.That(t, len(res), test.ShouldEqual, 1) // The annotated trigger image
 	test.That(t, meta, test.ShouldNotBeNil)
+}
+
+func TestImagesFromVisionServiceSource(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+
+	imgA, _ := camera.NamedImageFromImage(a, "manipulated", "image/jpeg", data.Annotations{})
+
+	imageSourceSvc := inject.NewVisionService("image_source_vision")
+	imageSourceSvc.CaptureAllFromCameraFunc = func(
+		ctx context.Context, cameraName string, opts viscapture.CaptureOptions, extra map[string]interface{},
+	) (viscapture.VisCapture, error) {
+		test.That(t, opts.ReturnImage, test.ShouldBeTrue)
+		return viscapture.VisCapture{Image: &imgA}, nil
+	}
+
+	fc := &filteredCamera{
+		conf: &Config{
+			Classifications: map[string]float64{"a": .8},
+			Objects:         map[string]float64{"b": .8},
+			WindowSeconds:   10,
+			ImageFrequency:  1.0,
+		},
+		logger: logger,
+		otherVisionServices: []vision.Service{
+			getDummyVisionService(),
+		},
+		buf:                     imagebuffer.NewImageBuffer(10, 1.0, 0, 0, logging.NewTestLogger(t), true, 0),
+		imageVisionService:      imageSourceSvc,
+		acceptedClassifications: map[string]map[string]float64{"": {"a": .8}},
+		acceptedObjects:         map[string]map[string]float64{"": {"b": .8}},
+	}
+
+	ctx := context.Background()
+
+	res, meta, err := fc.Images(ctx, nil, map[string]interface{}{data.FromDMString: true})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, res, test.ShouldNotBeNil)
+	test.That(t, len(res), test.ShouldEqual, 1)
+	test.That(t, meta, test.ShouldNotBeNil)
+
+	// Properties should return safe defaults since there's no underlying camera dependency.
+	props, err := fc.Properties(ctx)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, props.SupportsPCD, test.ShouldBeFalse)
 }
 
 func TestImageWithBufferedImages(t *testing.T) {


### PR DESCRIPTION
# Description
The filtered data camera is crucial for inspecting fish predictions in a visual manner. Currently it takes the image source from a configured camera. This does not work great for the new fish predictor which will stitch images form a camera together in its own process leading to bbox annotation being useless since they are overlayed on the unstitched image provided by the camera.

<img width="1568" height="1112" alt="Screenshot 2026-08-04 at 11 59 30 AM" src="https://github.com/user-attachments/assets/49c4f9cb-9f83-4acc-a7bf-8a1a57345eb9" />

This PR allows for a new config called `image_vision_service` which can replace the camera as the source of the image to upload and annotate

# Testing
- reloaded onto sim and made sure we now get proper base images to upload bbox annotaions onto 
<img width="1654" height="836" alt="Screenshot 2026-08-04 at 12 01 18 PM" src="https://github.com/user-attachments/assets/8bedbaf1-1c35-4bdd-8a91-565632de3156" />
